### PR TITLE
Mark the tar/zip/exe extracted in the destination dir

### DIFF
--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -40,7 +40,7 @@ class Tool_cmake(Tool):
 
     def unpack(self):
         destfile = os.path.join(self.cmake_path, 'bin', 'cmake.exe')
-        extract_exec(self.archive_file, self.builder.opts.tools_root_dir, dir_part = self.dir_part, check_file = destfile)
+        extract_exec(self.archive_file, self.builder.opts.tools_root_dir, dir_part = self.dir_part, check_file = destfile, check_mark=True)
 
     def get_path(self):
         return os.path.join(self.cmake_path, 'bin')
@@ -61,7 +61,7 @@ class Tool_meson(Tool):
         builder.meson = os.path.join(self.build_dir, 'meson.py')
 
     def unpack(self):
-        extract_exec(self.archive_file, self.builder.opts.tools_root_dir, dir_part = self.dir_part, check_file = self.builder.meson)
+        extract_exec(self.archive_file, self.builder.opts.tools_root_dir, dir_part = self.dir_part, check_file = self.builder.meson, check_mark=True)
 
     def get_path(self):
         pass
@@ -82,7 +82,7 @@ class Tool_ninja(Tool):
 
     def unpack(self):
         destfile = os.path.join(self.ninja_path, 'ninja.exe')
-        extract_exec(self.archive_file, self.ninja_path, check_file = destfile)
+        extract_exec(self.archive_file, self.ninja_path, check_file = destfile, check_mark=True)
 
     def get_path(self):
         return self.ninja_path
@@ -103,7 +103,7 @@ class Tool_nuget(Tool):
 
     def unpack(self):
         # We download directly the exe file so we copy it on the tool directory ...
-        extract_exec(self.archive_file, self.build_dir, check_file = self.builder.nuget)
+        extract_exec(self.archive_file, self.build_dir, check_file = self.builder.nuget, check_mark=True)
 
     def get_path(self):
         # No need to add the path, we use the full file name
@@ -128,7 +128,7 @@ class Tool_perl(Tool):
 
     def unpack(self):
         destfile = os.path.join(self.perl_path, 'perl.exe')
-        extract_exec(self.archive_file, self.build_dir, check_file = destfile)
+        extract_exec(self.archive_file, self.build_dir, check_file = destfile, check_mark=True)
 
     def get_path(self):
         return self.perl_path
@@ -171,7 +171,7 @@ class Tool_yasm(Tool):
     def unpack(self):
         # We download directly the exe file so we copy it on the tool directory ...
         destfile = os.path.join(self.build_dir, 'yasm.exe')
-        extract_exec(self.archive_file, self.build_dir, check_file = destfile, force_dest = destfile)
+        extract_exec(self.archive_file, self.build_dir, check_file = destfile, force_dest = destfile, check_mark=True)
 
     def get_path(self):
         return self.yasm_path

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -111,7 +111,10 @@ class Project(object):
 
         if os.path.exists(self.build_dir):
             print_debug("directory %s already exists" % (self.build_dir,))
-            self.update_build_dir()
+            if self.update_build_dir():
+                if os.path.exists(self.patch_dir):
+                    print_log("Copying files from %s to %s" % (self.patch_dir, self.build_dir))
+                    self.builder.copy_all(self.patch_dir, self.build_dir)
         else:
             self.unpack()
             if os.path.exists(self.patch_dir):

--- a/gvsbuild/utils/utils.py
+++ b/gvsbuild/utils/utils.py
@@ -17,6 +17,8 @@
 
 import os
 import stat
+import time
+import shutil
 
 from .simple_ui import print_debug
 
@@ -35,6 +37,18 @@ def _rmtree_error_handler(func, path, exc_info):
         print_debug('rmtree:read-only file/path (%s)' % (path, ))
     else:
         raise
+
+def rmtree_full(dest_dir, retry=False):
+    if retry:
+        for delay in [ 0.1, 0.2, 0.4, 0.8]:
+            try:
+                shutil.rmtree(dest_dir, onerror=_rmtree_error_handler)
+                break
+            except:
+                # wait a little, don't ask me why ;(
+                time.sleep(delay)
+    else:
+        shutil.rmtree(dest_dir, onerror=_rmtree_error_handler)
 
 class ordered_set(set):
     def __init__(self):


### PR DESCRIPTION
This handle automatically an update version of a project (no need to delete manually
the build\win32\... dir and a break in the extraction of the files.

On the update of the build dir the patches are copied again

P.S. I'm working on a parallel build of the projects, to speed up things, and during the test I ended up with directory half extracted or corrupted so it's really useful to have this.