### PR TITLE
libuv: update to version 1.11.0

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -936,8 +936,8 @@ class Project_libuv(Tarball, Project):
     def __init__(self):
         Project.__init__(self,
             'libuv',
-            archive_url = 'https://github.com/libuv/libuv/archive/v1.9.1.tar.gz',
-            hash = 'a6ca9f0648973d1463f46b495ce546ddcbe7cce2f04b32e802a15539e46c57ad',
+            archive_url = 'https://github.com/libuv/libuv/archive/v1.11.0.tar.gz',
+            hash = '6ec7eec6ecc24b1a8ffedebedb2fe9313fffb5410de89aaf784dd01080411c7a',
             )
 
     def build(self):
@@ -949,7 +949,11 @@ class Project_libuv(Tarball, Project):
         if self.builder.x64:
             platform = r'x64'
 
+        tmp_python = os.getenv('PYTHON')
+        os.environ["PYTHON"] = 'c:\python27\python'
         os.system(r'%s\vcbuild.bat build static %s %s' % (self._get_working_dir(), self.builder.opts.configuration, platform))
+        if tmp_python != None:
+            os.environ["PYTHON"] = tmp_python
 
         self.install(r'include\pthread-barrier.h include\libuv')
         self.install(r'include\stdint-msvc2008.h include\libuv')


### PR DESCRIPTION
libuv uses Python 2.7.9 so you should be installed in C:\Python27 for building