### PR TITLE
enhance gvsbuild

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -27,7 +27,8 @@ from .utils.simple_ui import print_debug
 from .utils.utils import convert_to_msys
 from .utils.base_expanders import Tarball, GitRepo
 from .utils.base_project import Project
-from .utils.base_builders import Meson, MercurialCmakeProject
+from .utils.base_builders import Meson, GitCmakeProject
+
 
 class Project_adwaita_icon_theme(Tarball, Project):
     def __init__(self):
@@ -1363,6 +1364,6 @@ class Project_zlib(Tarball, Project):
 
 Project.add(Project_zlib())
 
-Project.add(MercurialCmakeProject('pycairo', repo_url='git+ssh://git@github.com:muntyan/pycairo-gtk-win32.git', dependencies = ['cmake', 'cairo']))
-Project.add(MercurialCmakeProject('pygobject', repo_url='git+ssh://git@github.com:muntyan/pygobject-gtk-win32.git', dependencies = ['cmake', 'glib']))
-Project.add(MercurialCmakeProject('pygtk', repo_url='git+ssh://git@github.com:muntyan/pygtk-gtk-win32.git', dependencies = ['cmake', 'gtk', 'pycairo', 'pygobject']))
+Project.add(GitCmakeProject('pycairo', repo_url='git+ssh://git@github.com:muntyan/pycairo-gtk-win32.git', dependencies = ['cmake', 'cairo']))
+Project.add(GitCmakeProject('pygobject', repo_url='git+ssh://git@github.com:muntyan/pygobject-gtk-win32.git', dependencies = ['cmake', 'glib']))
+Project.add(GitCmakeProject('pygtk', repo_url='git+ssh://git@github.com:muntyan/pygtk-gtk-win32.git', dependencies = ['cmake', 'gtk', 'pycairo', 'pygobject']))

--- a/gvsbuild/utils/base_builders.py
+++ b/gvsbuild/utils/base_builders.py
@@ -24,7 +24,7 @@ import shutil
 
 from .utils import _rmtree_error_handler
 from .simple_ui import print_debug
-from .base_expanders import Tarball, MercurialRepo
+from .base_expanders import Tarball, MercurialRepo, GitRepo
 from .base_project import Project
 
 class Meson(Project):
@@ -59,10 +59,15 @@ class CmakeProject(Tarball, Project):
 
     def build(self):
         cmake_config = 'Debug' if self.builder.opts.configuration == 'debug' else 'RelWithDebInfo'
-        self.exec_vs('cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="%(pkg_dir)s" -DGTK_DIR="%(gtk_dir)s" -DCMAKE_BUILD_TYPE=' + cmake_config)
+        safe_cmake_ext_cmdline=' ' + self.cmake_ext_cmdline + ' ' if hasattr(self, 'cmake_ext_cmdline') else ''
+        self.exec_vs('cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="%(pkg_dir)s" -DGTK_DIR="%(gtk_dir)s" -DCMAKE_BUILD_TYPE='+cmake_config+safe_cmake_ext_cmdline)
         self.exec_vs('nmake /nologo')
         self.exec_vs('nmake /nologo install')
 
 class MercurialCmakeProject(MercurialRepo, CmakeProject):
+    def __init__(self, name, **kwargs):
+        CmakeProject.__init__(self, name, **kwargs)
+
+class GitCmakeProject(GitRepo, CmakeProject):
     def __init__(self, name, **kwargs):
         CmakeProject.__init__(self, name, **kwargs)

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -117,12 +117,15 @@ class Builder(object):
             # Use output redirect will help to ignore the header part vcvars family print
             # Which make later parser more reliable
             cmd_details='cmd.exe /c ""%s" && set>%s"' % (vcvars_bat, temp_env_out_path)
-            retcode = subprocess.call(cmd_details, shell=True)
-            if retcode==0:
-                with open(temp_env_out_path) as temp_env_out_file:
-                    output=temp_env_out_file.read()
-            else:
-                raise Exception("Some error happened when try to run vcvars family, cmd: %s, cwd: %s" % (cmd_details, os.getcwd()))
+
+            try:
+                subprocess.check_call(cmd_details, shell=True)
+            except subprocess.CalledProcessError as exc:
+                print_debug("Some error happened when try to run vcvars family, cmd: %s, cwd: %s" % (cmd_details, os.getcwd()))
+                raise
+
+            with open(temp_env_out_path) as temp_env_out_file:
+                output=temp_env_out_file.read()
         finally:
             if os.path.exists(temp_env_out_path):
                 os.unlink(temp_env_out_path)
@@ -386,7 +389,7 @@ class Builder(object):
             self.__add_path(env, add_path)
         try:
             subprocess.check_call(args, cwd=working_dir, env=env, shell=True)
-        except Exception as exc:
+        except subprocess.CalledProcessError as exc:
             print_debug('Error happened when try to run:%s, cwd:%s'%(args, working_dir))
             raise
 

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -20,6 +20,7 @@ Main builder class
 """
 
 import os
+import tempfile
 import shutil
 import subprocess
 import traceback
@@ -90,11 +91,17 @@ class Builder(object):
         # Verify VS exists at the indicated location, and that it supports the required target
         if opts.platform == 'Win32':
             vcvars_bat = os.path.join(opts.vs_install_path, 'VC', 'bin', 'vcvars32.bat')
+            # Make VS 2017 works
+            if not os.path.exists(vcvars_bat):
+                vcvars_bat=os.path.join(opts.vs_install_path, 'VC', 'Auxiliary', 'Build', 'vcvars32.bat')
         else:
             vcvars_bat = os.path.join(opts.vs_install_path, 'VC', 'bin', 'amd64', 'vcvars64.bat')
             # make sure it works even with VS Express
             if not os.path.exists(vcvars_bat):
                 vcvars_bat = os.path.join(opts.vs_install_path, 'VC', 'bin', 'x86_amd64', 'vcvarsx86_amd64.bat')
+            # Make VS 2017 works
+            if not os.path.exists(vcvars_bat):
+                vcvars_bat=os.path.join(opts.vs_install_path, 'VC', 'Auxiliary', 'Build', 'vcvars64.bat')
 
         if not os.path.exists(vcvars_bat):
             raise Exception("'%s' could not be found. Please check you have Visual Studio installed at '%s' and that it supports the target platform '%s'." % (vcvars_bat, opts.vs_install_path, opts.platform))
@@ -105,10 +112,25 @@ class Builder(object):
         self.add_env('LIBPATH', os.path.join(self.gtk_dir, 'lib'))
         self.add_env('PATH', os.path.join(self.gtk_dir, 'bin'))
 
-        output = subprocess.check_output('cmd.exe /c ""%s" && set"' % (vcvars_bat,), shell=True)
+        temp_env_out_path = tempfile.mktemp()
+        try:
+            # Use output redirect will help to ignore the header part vcvars family print
+            # Which make later parser more reliable
+            cmd_details='cmd.exe /c ""%s" && set>%s"' % (vcvars_bat, temp_env_out_path)
+            retcode = subprocess.call(cmd_details, shell=True)
+            if retcode==0:
+                with open(temp_env_out_path) as temp_env_out_file:
+                    output=temp_env_out_file.read()
+            else:
+                raise Exception("Some error happened when try to run vcvars family, cmd: %s, cwd: %s" % (cmd_details, os.getcwd()))
+        finally:
+            if os.path.exists(temp_env_out_path):
+                os.unlink(temp_env_out_path)
+
         self.vs_env = {}
         for l in output.splitlines():
-            k, v = l.decode('utf-8').split("=", 1)
+            # python 3 str is not bytes and no need to decode
+            k, v = (l.decode('utf-8') if isinstance(l, bytes) else l).split("=", 1)
             # Be sure to have PATH in upper case because we need to manipulate it
             if k.upper() == 'PATH':
                 k = 'PATH'
@@ -362,7 +384,11 @@ class Builder(object):
             else:
                 env = dict(os.environ)
             self.__add_path(env, add_path)
-        subprocess.check_call(args, cwd=working_dir, env=env, shell=True)
+        try:
+            subprocess.check_call(args, cwd=working_dir, env=env, shell=True)
+        except Exception as exc:
+            print_debug('Error happened when try to run:%s, cwd:%s'%(args, working_dir))
+            raise
 
     def __add_path(self, env, folder):
         key = None


### PR DESCRIPTION
1. add vs 2017 support
2. more accurate path variable fetch and merge
3. python 2/3 byte,str problem friend
4. subprocess accurate run and non zero catch for easy debug
5. add CmakeProject a cmake_ext_cmdline parameter to make CmakeProject more flexible
6. add a new GitCmakeProject project type which is needed for pygobject
7. adjust some project to use GitCmakeProject
notes: pyojbect can not build successful