### PR TITLE
build ffmpeg with mpeg1 video encoding/decoding support

### DIFF
--- a/ffmpeg/0001-lavc-mpegvideo_enc-allow-low_delay-for-non-MPEG2-cod.patch
+++ b/ffmpeg/0001-lavc-mpegvideo_enc-allow-low_delay-for-non-MPEG2-cod.patch
@@ -1,0 +1,32 @@
+From dc70ea8c193a08aebb1e0eeb2accc12322497ade Mon Sep 17 00:00:00 2001
+From: Stefano Sabatini <stefasab@gmail.com>
+Date: Tue, 23 May 2017 12:22:41 +0200
+Subject: [PATCH] lavc/mpegvideo_enc: allow low_delay for non MPEG2 codecs
+ depending on strict_std_compliance
+
+Forcing low_delay can be useful, even if not officially supported.
+---
+ libavcodec/mpegvideo_enc.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/libavcodec/mpegvideo_enc.c b/libavcodec/mpegvideo_enc.c
+index db241c8..1003dea 100644
+--- a/libavcodec/mpegvideo_enc.c
++++ b/libavcodec/mpegvideo_enc.c
+@@ -671,9 +671,11 @@ FF_ENABLE_DEPRECATION_WARNINGS
+     }
+ 
+     if (s->avctx->flags & AV_CODEC_FLAG_LOW_DELAY) {
+-        if (s->codec_id != AV_CODEC_ID_MPEG2VIDEO) {
++        if (s->codec_id != AV_CODEC_ID_MPEG2VIDEO &&
++            s->strict_std_compliance >= FF_COMPLIANCE_NORMAL) {
+             av_log(avctx, AV_LOG_ERROR,
+-                  "low delay forcing is only available for mpeg2\n");
++                   "low delay forcing is only available for mpeg2, "
++                   "set strict_std_compliance to 'unofficial' or lower in order to allow it\n");
+             return -1;
+         }
+         if (s->max_b_frames != 0) {
+-- 
+1.9.1
+

--- a/ffmpeg/build/build.sh
+++ b/ffmpeg/build/build.sh
@@ -21,6 +21,8 @@ export PKG_CONFIG_PATH=$gtk_dir/lib/pkgconfig:$PKG_CONFIG_PATH
     --enable-swscale \
     --enable-avcodec \
     --enable-decoder=h264 \
+    --enable-decoder=mpeg1video \
+    --enable-encoder=mpeg1video \
     --enable-libx264 \
     --enable-gpl \
     --enable-encoder="libx264" \

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -234,7 +234,8 @@ class Project_ffmpeg(Tarball, Project):
             'ffmpeg',
             archive_url = 'http://ffmpeg.org/releases/ffmpeg-3.3.tar.xz',
             hash = '599e7f7c017221c22011c4037b88bdcd1c47cd40c1e466838bc3c465f3e9569d',
-            dependencies = [ 'yasm', 'x264' ]
+            dependencies = [ 'yasm', 'x264' ],
+            patches = [ '0001-lavc-mpegvideo_enc-allow-low_delay-for-non-MPEG2-cod.patch' ]
         )
 
     def build(self):


### PR DESCRIPTION
The patch in the ffmpeg dir is required since it allows to force low-delay mode
(can be dropped when a new release will be used).