### PR TITLE
By default run with a minimum path & environment.

### DIFF
--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -47,6 +47,7 @@ def get_options(args):
     opts.msys_dir = args.msys_dir
     opts.clean = args.clean
     opts.msbuild_opts = args.msbuild_opts
+    opts.use_env = args.use_env
     opts.no_deps = args.no_deps
     opts.check_hash = args.check_hash
     opts.skip = args.skip
@@ -194,6 +195,8 @@ Examples:
 
     p_build.add_argument('--msbuild-opts', default='',
                          help='Command line options to pass to msbuild.')
+    p_build.add_argument('--use-env', default=False, action='store_true',
+                         help='Use and keep the calling environment for LIB, LIBPATH, INCLUDE and PATH')
 
     p_build.add_argument('--skip', default='',
                          help='A comma separated list of project(s) not to build.')


### PR DESCRIPTION
Only the windows system paths are used ('c:\windows\...') together with the
ones containing'\git\'.
The INCLUDE, LIB and LIBPATH are reset before setting up the vs environment.
To maintain the old behavior use the --use-env option, similar to the
/useenv of the Visual Studio IDE.
This should reduce problems as the #188