### PR TITLE
fix cario x64 bit crash + apply version info to libpng16.dll

### DIFF
--- a/cairo/cairo.patch
+++ b/cairo/cairo.patch
@@ -1,0 +1,24 @@
+diff -ruN --strip-trailing-cr cairo/src/cairo-cache-private.h build/Win32/cairo/src/cairo-cache-private.h
+--- cairo/src/cairo-cache-private.h	2015-03-10 18:21:07.000000000 -0400
++++ build/Win32/cairo/src/cairo-cache-private.h	2015-12-04 10:16:00.304925900 -0500
+@@ -84,7 +84,7 @@
+  * not be initialized if so desired.
+  **/
+ typedef struct _cairo_cache_entry {
+-    unsigned long hash;
++    unsigned long long hash;
+     unsigned long size;
+ } cairo_cache_entry_t;
+ 
+diff -ruN --strip-trailing-cr cairo/src/cairo-scaled-font.c build/Win32/cairo/src/cairo-scaled-font.c
+--- cairo/src/cairo-scaled-font.c	2015-03-10 18:21:07.000000000 -0400
++++ build/Win32/cairo/src/cairo-scaled-font.c	2015-12-04 10:16:00.315176900 -0500
+@@ -2852,7 +2852,7 @@
+     if (unlikely (page == NULL))
+ 	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
+ 
+-    page->cache_entry.hash = (unsigned long) scaled_font;
++    page->cache_entry.hash = (unsigned long long) scaled_font;
+     page->cache_entry.size = 1; /* XXX occupancy weighting? */
+     page->num_glyphs = 0;
+ 

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -70,6 +70,7 @@ class Project_cairo(Tarball, Project):
             archive_url = 'http://cairographics.org/snapshots/cairo-1.15.2.tar.xz',
             hash = '268cc265a7f807403582f440643064bf52896556766890c8df7bad02d230f6c9',
             dependencies = ['fontconfig', 'glib', 'pixman', 'libpng'],
+            patches = ['cairo.patch']
             )
 
     def build(self):

--- a/libpng/CMakeLists.txt
+++ b/libpng/CMakeLists.txt
@@ -35,7 +35,7 @@ enable_testing()
 
 set(PNGLIB_MAJOR 1)
 set(PNGLIB_MINOR 6)
-set(PNGLIB_RELEASE 28)
+set(PNGLIB_RELEASE 32)
 set(PNGLIB_NAME libpng${PNGLIB_MAJOR}${PNGLIB_MINOR})
 set(PNGLIB_VERSION ${PNGLIB_MAJOR}.${PNGLIB_MINOR}.${PNGLIB_RELEASE})
 
@@ -356,6 +356,7 @@ set(libpng_sources
   pngwrite.c
   pngwtran.c
   pngwutil.c
+  scripts/pngwin.rc
 )
 set(pngtest_sources
   pngtest.c


### PR DESCRIPTION
(1) fix carios x64 bit crash
(2) apply version info to libpng16.dll

![image](https://user-images.githubusercontent.com/5375159/32396688-b0df8650-c0bc-11e7-8c21-b7c3ab38cc0d.png)

