### PR TITLE
Add project gobject-introspection.

### DIFF
--- a/gobject-introspection/00_glib_win_ver.patch
+++ b/gobject-introspection/00_glib_win_ver.patch
@@ -1,0 +1,18 @@
+--- "orig\\meson.build"	2017-12-06 16:50:52.499102700 +0100
++++ "gobject-introspection\\meson.build"	2017-12-06 16:54:05.752593500 +0100
+@@ -48,8 +48,13 @@
+   output: 'config.h'
+ )
+
+-# Always bumped to match our version
+-glib_version = '>=2.@0@.@1@'.format(gi_versions[1], gi_versions[2])
++if host_system != 'windows'
++  # Always bumped to match our version
++  glib_version = '>=2.@0@.@1@'.format(gi_versions[1], gi_versions[2])
++else
++  # windows, for now we have 2.52 & 2.54
++  glib_version = '>=2.52'
++endif
+
+ glib_dep = dependency('glib-2.0', version : glib_version,
+   fallback: ['glib', 'libglib_dep'])

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -173,6 +173,7 @@ class Builder(object):
             ('make',       'make'),
             ('md5sum',     'coreutils'),
             ('diff',       'diffutils'),
+            ('bison',       'bison'),
         ]
         missing = []
         for prog, pkg in msys_pkg:


### PR DESCRIPTION
The project is built from the 2.55 version using our 2.54 glib

This is a new tentative for #22, cleaned up and with a little patch . 
We build also the .gir/.typelib for gtk3 so, with a pygobject installation, 
is possible to use the new Gtk3 with the new python 3.5/3.6

As a little reference I've a little python/gtk3 app that now states:
```
DEBUG:root:Programma avviato ...
INFO:root:++ Programma avviato - versione 0.9.0
INFO:root:  Versione python: 3.6.3
INFO:root:  Versione glib: 2.54.2
INFO:root:  Versione gtk: 3.22.26

```
