### PR TITLE
Add wrapper for glib python scripts

### DIFF
--- a/glib-py-wrapper/glib-genmarshal.config
+++ b/glib-py-wrapper/glib-genmarshal.config
@@ -1,0 +1,1 @@
+python ${wd}\glib-genmarshal

--- a/glib-py-wrapper/glib-mkenums.config
+++ b/glib-py-wrapper/glib-mkenums.config
@@ -1,0 +1,1 @@
+python ${wd}\glib-mkenums

--- a/glib-py-wrapper/glib-py-wrapper.c
+++ b/glib-py-wrapper/glib-py-wrapper.c
@@ -1,0 +1,48 @@
+#include <glib.h>
+#include <string.h>
+#include <stdlib.h>
+
+int
+main (int    argc,
+      char **argv)
+{
+  GRegex* regex;
+  GString *cmd;
+  gchar **args;
+  gchar **exec;
+  gchar *cfg;
+  gchar *wd;
+  gchar *wn;
+  guint i;
+
+#ifdef G_OS_WIN32
+    args = g_win32_get_command_line ();
+#else
+    args = argv;
+#endif
+
+  /* Work directory. */
+  wd = g_path_get_dirname (args[0]);
+
+  /* Program name. */
+  wn = g_path_get_basename (args[0]);
+  wn = g_utf8_strdown (wn, -1);
+  if (g_str_has_suffix (wn, ".exe"))
+    wn[strlen (wn) - 4] = 0;
+
+  /* Program configuration. */
+  cfg = g_strdup_printf ("%s%s%s%s", wd, G_DIR_SEPARATOR_S, wn, ".config");
+  if (!g_file_get_contents (cfg, &cfg, NULL, NULL))
+    return -1;
+  exec = g_strsplit_set (cfg, "\r\n", -1);
+  if (exec == NULL)
+    return -1;
+
+  /* Command. */
+  regex = g_regex_new ("\\${wd}", G_REGEX_CASELESS, 0, NULL);
+  cmd = g_string_new (g_regex_replace_literal (regex, exec[0], -1, 0, wd, 0, NULL));
+  for (i = 1; i < argc; i++)
+    g_string_append_printf (cmd, " %s", args[i]);
+
+  return system (g_string_free (cmd, FALSE));
+}

--- a/glib-py-wrapper/meson.build
+++ b/glib-py-wrapper/meson.build
@@ -1,0 +1,9 @@
+
+project('glib-py-warpper', 'c')
+glib = dependency('glib-2.0')
+
+executable('glib-genmarshal', 'glib-py-wrapper.c', dependencies : glib, install : true)
+executable('glib-mkenums', 'glib-py-wrapper.c', dependencies : glib, install : true)
+
+install_data('glib-genmarshal.config', install_dir : get_option('bindir'))
+install_data('glib-mkenums.config', install_dir : get_option('bindir'))

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -391,6 +391,17 @@ class Project_glib_networking(Tarball, Project):
         self.install(r'.\COPYING share\doc\glib-networking')
 
 @project_add
+class Project_glib_py_wrapper(NullExpander, Meson):
+    def __init__(self):
+        Project.__init__(self,
+            'glib-py-wrapper',
+            dependencies = ['glib'],
+            )
+
+    def build(self):
+        Meson.build(self)
+
+@project_add
 class Project_glib_openssl(Tarball, Meson):
     def __init__(self):
         Project.__init__(self,


### PR DESCRIPTION
In glib 2.54 glib-genmarshal and glib-mkenums were rewritten in python.
It caused a problem in CMake scripts: find_program/add_custom_command
are not able to run python scripts without manual editing.