### PR TITLE
Wip/gi optional

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -65,10 +65,15 @@ class Project_atk(Tarball, Meson):
                 'pkg-config', 
                 'perl', 
                 'glib',
-                'gobject-introspection',
             ],
             )
-        self.add_param('-Ddisable_introspection=false')
+        if self.opts.enable_gi:
+            self.add_dependencies('gobject-introspection')
+            disable_gi = 'false'
+        else:
+            disable_gi = 'true'
+        
+        self.add_param('-Ddisable_introspection=%s' % (disable_gi, ))
         self.add_param('-Denable_docs=false')
 
     def build(self):
@@ -358,12 +363,17 @@ class Project_gdk_pixbuf(Tarball, Meson):
                 'jasper', 
                 'glib', 
                 'libpng',
-                'gobject-introspection',
             ],
             )
+        if self.opts.enable_gi:
+            self.add_dependencies('gobject-introspection')
+            enable_gi = 'true'
+        else:
+            enable_gi = 'false'
+
         self.add_param('-Djasper=true')
         self.add_param('-Dnative_windows_loaders=true') 
-        self.add_param('-Dgir=true') 
+        self.add_param('-Dgir=%s' % (enable_gi, )) 
         self.add_param('-Dman=false')
 
     def build(self):
@@ -1270,13 +1280,18 @@ class Project_pango(Tarball, Meson):
                 'cairo', 
                 'harfbuzz', 
                 'fribidi',
-                'gobject-introspection',
             ],
             patches = [ 
                 '001-ignore-help2man.patch', 
             ], 
             )
-        self.add_param('-Dgir=true')
+        if self.opts.enable_gi:
+            self.add_dependencies('gobject-introspection')
+            enable_gi = 'true'
+        else:
+            enable_gi = 'false'
+
+        self.add_param('-Dgir=%s' % (enable_gi, ))
 
     def build(self):
         Meson.build(self)

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -68,9 +68,11 @@ class Project_atk(Tarball, Meson):
                 'gobject-introspection',
             ],
             )
+        self.add_param('-Ddisable_introspection=false')
+        self.add_param('-Denable_docs=false')
 
     def build(self):
-        Meson.build(self, meson_params='-Ddisable_introspection=false -Denable_docs=false', make_tests=True)
+        Meson.build(self, make_tests=True)
         self.install(r'.\COPYING share\doc\atk')
 
 @project_add
@@ -359,12 +361,16 @@ class Project_gdk_pixbuf(Tarball, Meson):
                 'gobject-introspection',
             ],
             )
+        self.add_param('-Djasper=true')
+        self.add_param('-Dnative_windows_loaders=true') 
+        self.add_param('-Dgir=true') 
+        self.add_param('-Dman=false')
 
     def build(self):
         # We can experiment with a couple of options to give to meson:
         #    -Dbuiltin_loaders=all|windows
         #        Buld the loader inside the library
-        Meson.build(self, meson_params='-Djasper=true -Dnative_windows_loaders=true -Dgir=true -Dman=false')
+        Meson.build(self)
         self.install(r'.\COPYING share\doc\gdk-pixbuf')
 
     def post_install(self):
@@ -539,9 +545,10 @@ class Project_graphene(GitRepo, Meson):
             tag = None,
             dependencies = ['ninja', 'meson', 'pkg-config', 'glib'],
             )
-
+        self.add_param('-Dbenchmarks=false')
+        
     def build(self):
-        Meson.build(self, meson_params='-Dbenchmarks=false', make_tests=True)
+        Meson.build(self, make_tests=True)
         self.install(r'.\LICENSE share\doc\graphene')
 
 @project_add
@@ -738,9 +745,11 @@ class Project_json_glib(Tarball, Meson):
             hash = '2d7709a44749c7318599a6829322e081915bdc73f5be5045882ed120bb686dc8',
             dependencies = ['meson', 'ninja', 'pkg-config', 'perl', 'glib'],
             )
+        self.add_param('-Ddocs=false')
+        self.add_param('-Dintrospection=false')
 
     def build(self):
-        Meson.build(self, meson_params='-Ddocs=false -Dintrospection=false', make_tests=True)
+        Meson.build(self, make_tests=True)
 
         self.install(r'.\COPYING share\doc\json-glib')
 
@@ -826,7 +835,7 @@ class Project_libffi(GitRepo, Meson):
         self.install(r'LICENSE share\doc\libffi')
 
 @project_add
-class Project_libgxps(GitRepo, Project):
+class Project_libgxps(GitRepo, Meson):
     def __init__(self):
         Project.__init__(self,
             'libgxps',
@@ -836,9 +845,11 @@ class Project_libgxps(GitRepo, Project):
             dependencies = ['meson', 'ninja', 'pkg-config', 'glib', 'libarchive', 'cairo', 'libpng', 'libjpeg-turbo', 'libtiff-4', 'gtk3', ],
             patches = ['0001-Fixes-font-scaling-issue-when-converting-xps-to-pdf.patch'],
             )
+        self.add_param('-Dwith-liblcms2=false')
+        self.add_param('-Denable-test=false')
 
     def build(self):
-        Meson.build(self, meson_params='-Dwith-liblcms2=false -Denable-test=false')
+        Meson.build(self)
 
         self.install(r'.\COPYING share\doc\libgxps')
 
@@ -1171,7 +1182,6 @@ class Project_openssl(Tarball, Project):
 
     def build(self):
         common_options = r'no-ssl2 no-ssl3 no-comp --openssldir=./'
-        add_path = None
 
         debug_option = ''
         if self.builder.opts.configuration == 'debug':
@@ -1266,9 +1276,10 @@ class Project_pango(Tarball, Meson):
                 '001-ignore-help2man.patch', 
             ], 
             )
+        self.add_param('-Dgir=true')
 
     def build(self):
-        Meson.build(self, meson_params='-Dgir=true')
+        Meson.build(self)
         self.install(r'COPYING share\doc\pango')
 
 @project_add
@@ -1312,9 +1323,10 @@ class Project_pkg_config(GitRepo, Meson):
             patches = [ '0001-vs2013.patch', 
                       ], 
             )
+        self.add_param('-Dtests=false')
 
     def build(self):
-        Meson.build(self, meson_params='-Dtests=false')
+        Meson.build(self)
         self.install(r'.\COPYING share\doc\pkgconf')
 
     def post_install(self):

--- a/gvsbuild/utils/base_builders.py
+++ b/gvsbuild/utils/base_builders.py
@@ -30,6 +30,15 @@ from .base_project import Project
 class Meson(Project):
     def __init__(self, name, **kwargs):
         Project.__init__(self, name, **kwargs)
+        self._ensure_params()
+
+    def _ensure_params(self):
+        if not hasattr(self, 'params'):
+            self.params = []
+                    
+    def add_param(self, par):
+        self._ensure_params()
+        self.params.append(par)
 
     def build(self, meson_params=None, make_tests=False):
         # where we build, with ninja, the library
@@ -42,8 +51,14 @@ class Meson(Project):
         # First we check if we need to generate the meson build files
         if not os.path.isfile(os.path.join(ninja_build, 'build.ninja')):
             self.builder.make_dir(ninja_build)
+            # base params 
+            self._ensure_params()
+            if self.params:
+                add_opts = ' '.join(self.params) + ' '
+            else:
+                add_opts = ''
             # debug info
-            add_opts = '--buildtype ' + self.builder.opts.configuration
+            add_opts += '--buildtype ' + self.builder.opts.configuration
             if meson_params:
                 add_opts += ' ' + meson_params
             # pyhon meson.py src_dir ninja_build_dir --prefix gtk_bin options

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -33,6 +33,11 @@ GVSBUILD_PROJECT = 1
 GVSBUILD_TOOL = 2
 GVSBUILD_GROUP = 3
 
+class Options(object):
+    def __init__(self):
+        # Only the one used by the projects
+        self.enable_gi = False
+
 class Project(object):
     def __init__(self, name, **kwargs):
         object.__init__(self)
@@ -61,6 +66,8 @@ class Project(object):
     name_len = 0
     # List of class/type to add, now not at import time but after some options are parsed
     _reg_prj_list = []
+    # build option 
+    opts = Options()
 
     def __str__(self):
         return self.name
@@ -78,6 +85,9 @@ class Project(object):
     def post_install(self):
         pass
 
+    def add_dependency(self, dep):
+        self.dependencies.append(dep)
+        
     def exec_cmd(self, cmd, working_dir=None, add_path=None):
         self.builder.exec_cmd(cmd, working_dir=working_dir, add_path=add_path)
 

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -58,6 +58,7 @@ def get_options(args):
     opts.clean_built = args.clean_built
     opts.py_egg = args.py_egg
     opts.py_wheel = args.py_wheel
+    opts.enable_gi = args.enable_gi
 
     if opts.make_zip and opts.no_deps:
         error_exit('Options --make-zip and --no-deps are not compatible')
@@ -246,6 +247,8 @@ Examples:
                          help="pycairo/pygobject: build also the egg distribution format")
     p_build.add_argument('--py-wheel', default=False, action='store_true',
                          help="pycairo/pygobject: build also the wheel distribution format")
+    p_build.add_argument('--enable-gi', default=False, action='store_true',
+                         help="Create, for the gtk stack, the .gir/.typelib files for gobject introspection")
 
     p_build.add_argument('project', nargs='+',
                          help='Project(s) to build.')

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -24,12 +24,10 @@ import os
 import sys
 
 from .base_project import Project, GVSBUILD_PROJECT, GVSBUILD_TOOL, GVSBUILD_GROUP, GVSBUILD_IGNORE
+from .base_project import Options
 from .builder import Builder
 from .utils import ordered_set
 from .simple_ui import error_exit, print_debug
-
-class Options(object):
-    pass
 
 def get_options(args):
     opts = Options()


### PR DESCRIPTION
This PR sets the gi gir/typelib disabled by default only for the gtk/gtk3 stack, leaving the other project as before (lgi, pygobject,  ... are buildable)

If you don't need python specific stuff you can use, for the full build, also an embedded version.

Tested for gtk/gtk3 in 32 bit mode, release & debug and in 64 bit mode, only debug.

If it's ok to merge I can fix also the other projects (graphene builds the gir if the gi lib is present, so if you build lgi before graphene you have the gir).

With best regards