### PR TITLE
Add instructions to install pylauncher and gi settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ HexChat developers decided that their script should focus on their specific need
 
 1. Install the following build tools and dependencies:
 
-    * [Visual Studio for Windows Desktop](http://www.visualstudio.com/downloads) - 2013, 2015 and 2017 are currently supported.
+    * [Visual Studio and Build Tools](http://www.visualstudio.com/downloads) - 2013, 2015 and 2017 are currently supported.
+    We recommend installing Visual Studio Community 2017 and Visual Studio Build Tools with the Visual C++ build tools Workload.
+    This comes with VS version 15 (15.9) and Windows 10 SDK (10.0.17763.0)
     * [msys2](https://msys2.github.io/)
-    * [Python 3.6](https://www.python.org/ftp/python/3.6.2/python-3.6.2-amd64.exe) (install in C:\Python36 or use the --python-dir option to tell the script the correct location), or other package like [Miniconda 3](https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe)
+    * [Python 3.7](https://www.python.org/downloads/windows/) (install in C:\Python37 or use the --python-dir option to tell the script the correct location), or other package like [Miniconda 3](https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe)
+    * [pylauncher](https://bitbucket.org/vinay.sajip/pylauncher/downloads/)
 
 1. Follow the instructions on the msys2 page to update the core packages. The needed packages for the script (make, diffutils, ...) are download and installed automatically if not presents in the msys2 installation.
 
@@ -43,6 +46,13 @@ HexChat developers decided that their script should focus on their specific need
     python .\build.py build -p x64 gtk3
     ```
 
+    If you are going to build the GTK+ stack for GObject Introspection as well,
+    make sure that you are building the 64-bit version, if you have 64-bit
+    version of Python installed:
+    ```
+    python .\build.py build -p x64 --enable-gi gtk3
+    ```
+    
     For more information about the possible commands. Run
 
     ```


### PR DESCRIPTION
Fixes #285 and #273. Pylauncher is needed because meson needs it launch python subprocesses. Using the platform when building to match the installed Python platform is required when trying to build GObject Introspection, otherwise Python.h errors occur. Also added more detail for how to install a Visual Studio.

Signed-off-by: Dan Yeaw <dan@yeaw.me>