### PR TITLE
Add more python versions and wheels

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,24 +8,39 @@ environment:
     DOWNLOAD_DIR: _download_cache
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
     PATH: C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Program Files\Git\cmd
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    VS_VER: "14"
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      VS_VER: "14"
-      PLATFORM: "x86"
-      PYTHON: C:\Python36\python.exe
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      VS_VER: "14"
-      PLATFORM: "x64"
-      PYTHON: C:\Python36-x64\python.exe
+    - PLATFORM: "x86"
+      MSVC_PLATFORM: "Win32"
+      PYTHON: \python.exe
+    - PLATFORM: "x64"
+      MSVC_PLATFORM: "x64"
+      PYTHON: -x64\python.exe
+
+install:
+  - |
+    C:\Python35%PYTHON% -m pip install --upgrade pip
+    C:\Python35%PYTHON% -m pip install wheel
+    C:\Python36%PYTHON% -m pip install --upgrade pip
+    C:\Python36%PYTHON% -m pip install wheel
+    C:\Python37%PYTHON% -m pip install --upgrade pip
+    C:\Python37%PYTHON% -m pip install wheel
 
 build_script:
-  - "%PYTHON% build.py build --archives-download-dir=%DOWNLOAD_DIR% --platform=%PLATFORM% --vs-ver=%VS_VER% -k --enable-gi enchant gtk gtk3-full pycairo pygobject lz4"
+  - C:\Python36%PYTHON% build.py build --archives-download-dir=%DOWNLOAD_DIR% --platform=%PLATFORM% --vs-ver=%VS_VER% --enable-gi --py-wheel gtk3-full pycairo pygobject
+  - C:\Python35%PYTHON% build.py build --archives-download-dir=%DOWNLOAD_DIR% --platform=%PLATFORM% --vs-ver=%VS_VER% --enable-gi --py-wheel pycairo pygobject
+  - C:\Python37%PYTHON% build.py build --archives-download-dir=%DOWNLOAD_DIR% --platform=%PLATFORM% --vs-ver=%VS_VER% --enable-gi --py-wheel pycairo pygobject
   - set PATH=%PATH%;C:\msys64\usr\bin
-  - IF "%PLATFORM%"=="x86" tar.exe -zcf gvsbuild-vs%VS_VER%-%PLATFORM%.tar.gz -C /c/gtk-build/gtk/Win32 release
-  - IF "%PLATFORM%"=="x64" tar.exe -zcf gvsbuild-vs%VS_VER%-%PLATFORM%.tar.gz -C /c/gtk-build/gtk/x64 release
+  - tar.exe -zcf gvsbuild-vs%VS_VER%-%PLATFORM%.tar.gz -C /c/gtk-build/gtk/%MSVC_PLATFORM% release
+  - tar.exe -zxf gvsbuild-vs%VS_VER%-%PLATFORM%.tar.gz --exclude include --exclude *.pdb --exclude *.exe
+  - mkdir gtkdist
+  - mv release gtkdist/gtk3-%MSVC_PLATFORM%
 
 artifacts:
   - path: gvsbuild-vs%VS_VER%-%PLATFORM%.tar.gz
+  - path: gtkdist
+    name: gtk3-%MSVC_PLATFORM%
 
 cache:
   - '%DOWNLOAD_DIR%'

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -730,8 +730,8 @@ class Project_gtk3_24(Project_gtk_base):
         Project.__init__(self,
             'gtk3',
             prj_dir='gtk3-24',
-            archive_url = 'http://ftp.acc.umu.se/pub/GNOME/sources/gtk+/3.24/gtk+-3.24.6.tar.xz',
-            hash = '9495439de02860e5d67cc594b5075ca11f51fe9ff67fd547315827e693ec52e0',
+            archive_url = 'http://ftp.acc.umu.se/pub/GNOME/sources/gtk+/3.24/gtk+-3.24.1.tar.xz',
+            hash = '68387be307b99aadcdc653561d7a2a7f0113b93561fb18ded7075ec9ced5b02f',
             dependencies = ['atk', 'gdk-pixbuf', 'pango', 'libepoxy'],
             )
         if Project.opts.enable_gi:

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -730,8 +730,8 @@ class Project_gtk3_24(Project_gtk_base):
         Project.__init__(self,
             'gtk3',
             prj_dir='gtk3-24',
-            archive_url = 'http://ftp.acc.umu.se/pub/GNOME/sources/gtk+/3.24/gtk+-3.24.7.tar.xz',
-            hash = '52121144a2df4babed75eb5f34de130a46420101fde3ae216d3142df8a481520',
+            archive_url = 'http://ftp.acc.umu.se/pub/GNOME/sources/gtk+/3.24/gtk+-3.24.6.tar.xz',
+            hash = '9495439de02860e5d67cc594b5075ca11f51fe9ff67fd547315827e693ec52e0',
             dependencies = ['atk', 'gdk-pixbuf', 'pango', 'libepoxy'],
             )
         if Project.opts.enable_gi:

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -490,8 +490,8 @@ class Project_gobject_introspection(Tarball, Meson):
     def __init__(self):
         Project.__init__(self,
             'gobject-introspection',
-            archive_url = 'http://ftp.acc.umu.se/pub/GNOME/sources/gobject-introspection/1.58/gobject-introspection-1.58.0.tar.xz',
-            hash = '27c1590a32749de0a5481ce897772547043e94bccba4bc0a7edb3d8513e401ec',
+            archive_url = 'http://ftp.acc.umu.se/pub/GNOME/sources/gobject-introspection/1.60/gobject-introspection-1.60.0.tar.xz',
+            hash = '9efe4090cb59717126701e97062e784773f800b8d47af14c4d278ebf194df35d',
             dependencies = [
                 'ninja',
                 'meson',
@@ -1636,8 +1636,8 @@ class Project_pygobject(Tarball, Project):
     def __init__(self):
         Project.__init__(self,
             'pygobject',
-            archive_url = 'https://ftp.acc.umu.se/pub/GNOME/sources/pygobject/3.28/pygobject-3.28.3.tar.xz',
-            hash = '3dd3e21015d06e00482ea665fc1733b77e754a6ab656a5db5d7f7bfaf31ad0b0',
+            archive_url = 'https://ftp.acc.umu.se/pub/GNOME/sources/pygobject/3.32/pygobject-3.32.0.tar.xz',
+            hash = '83f4d7e59fde6bc6b0d39c5e5208574802f759bc525a4cb8e7265dfcba45ef29',
             dependencies = ['python', 'pycairo', 'gobject-introspection', 'libffi'],
             )
 

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -730,8 +730,8 @@ class Project_gtk3_24(Project_gtk_base):
         Project.__init__(self,
             'gtk3',
             prj_dir='gtk3-24',
-            archive_url = 'http://ftp.acc.umu.se/pub/GNOME/sources/gtk+/3.24/gtk+-3.24.1.tar.xz',
-            hash = '68387be307b99aadcdc653561d7a2a7f0113b93561fb18ded7075ec9ced5b02f',
+            archive_url = 'http://ftp.acc.umu.se/pub/GNOME/sources/gtk+/3.24/gtk+-3.24.7.tar.xz',
+            hash = '52121144a2df4babed75eb5f34de130a46420101fde3ae216d3142df8a481520',
             dependencies = ['atk', 'gdk-pixbuf', 'pango', 'libepoxy'],
             )
         if Project.opts.enable_gi:

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -1610,8 +1610,8 @@ class Project_pycairo(Tarball, Project):
     def __init__(self):
         Project.__init__(self,
             'pycairo',
-            archive_url = 'https://github.com/pygobject/pycairo/releases/download/v1.17.1/pycairo-1.17.1.tar.gz',
-            hash = '0f0a35ec923d87bc495f6753b1e540fd046d95db56a35250c44089fbce03b698',
+            archive_url = 'https://github.com/pygobject/pycairo/releases/download/v1.18.0/pycairo-1.18.0.tar.gz',
+            hash = 'abd42a4c9c2069febb4c38fe74bfc4b4a9d3a89fea3bc2e4ba7baff7a20f783f',
             dependencies = ['cairo', 'python'],
             )
 


### PR DESCRIPTION
To provide a GTK3 build together with bindings for all recent python versions. I also added a zip file without the includes and the pdbs which is easier to use for windows users.