### PR TITLE
Wip/auto python

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,18 +8,19 @@ environment:
     DOWNLOAD_DIR: _download_cache
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
     PATH: C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Program Files\Git\cmd
+    PYTHON: C:\Python37\python.exe
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       VS_VER: "14"
       PLATFORM: "x86"
-      PYTHON: C:\Python36\python.exe
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       VS_VER: "14"
       PLATFORM: "x64"
-      PYTHON: C:\Python36-x64\python.exe
 
 build_script:
-  - "%PYTHON% build.py build --archives-download-dir=%DOWNLOAD_DIR% --platform=%PLATFORM% --vs-ver=%VS_VER% -k --enable-gi enchant gtk gtk3-full pycairo pygobject lz4"
+  - "%PYTHON% build.py build --archives-download-dir=%DOWNLOAD_DIR% --platform=%PLATFORM% --vs-ver=%VS_VER% -k --enable-gi --py-wheel --py-egg --python-ver 3.7 enchant gtk gtk3-full pycairo pygobject lz4"
+  - "%PYTHON% build.py build --archives-download-dir=%DOWNLOAD_DIR% --platform=%PLATFORM% --vs-ver=%VS_VER% -k --fast-build --clean-built --py-wheel --py-egg --python-ver 3.6 pycairo pygobject"
+  - "%PYTHON% build.py build --archives-download-dir=%DOWNLOAD_DIR% --platform=%PLATFORM% --vs-ver=%VS_VER% -k --fast-build --clean-built --py-wheel --py-egg --python-ver 3.5 pycairo pygobject"
   - set PATH=%PATH%;C:\msys64\usr\bin
   - IF "%PLATFORM%"=="x86" tar.exe -zcf gvsbuild-vs%VS_VER%-%PLATFORM%.tar.gz -C /c/gtk-build/gtk/Win32 release
   - IF "%PLATFORM%"=="x64" tar.exe -zcf gvsbuild-vs%VS_VER%-%PLATFORM%.tar.gz -C /c/gtk-build/gtk/x64 release
@@ -29,6 +30,7 @@ artifacts:
 
 cache:
   - '%DOWNLOAD_DIR%'
+  - c:\gtk-build\tools
 
 deploy: off
 

--- a/gvsbuild/groups.py
+++ b/gvsbuild/groups.py
@@ -59,6 +59,23 @@ class Group_Gtk3_Full(Group):
             )
 
 @group_add
+class Group_Tools_Check(Group):
+    '''
+    Group to use all the tools handled by the script, to see at a glance if everything
+    seems ok after (big) changes on the tools
+    '''
+    def __init__(self):
+        Group.__init__(self,
+            'tools-check',
+            dependencies = [
+                'lmdb',
+                'x264',
+                'libjpeg-turbo',
+                'grpc',
+                ],
+            )
+
+@group_add
 class Group_All(Group):
     def __init__(self):
         all_prj = [x.name for x in Project._projects if x.type == GVSBUILD_PROJECT]

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -808,6 +808,7 @@ class Project_icu(Tarball, Project):
             'icu',
             archive_url = 'http://download.icu-project.org/files/icu4c/63.1/icu4c-63_1-src.zip',
             hash = '3d957deabf75e96c35918355eac4da3e728fc222b9b4bdb2663652f76ee51772',
+            version='63.1',
             )
 
     def build(self):
@@ -820,6 +821,7 @@ class Project_icu(Tarball, Project):
         self.push_location('.\icu')
         self.exec_msbuild(r'source\allinone\allinone.sln /t:cal')
 
+        self.install(r'.\pc-files\* lib\pkgconfig')
         self.install(r'.\LICENSE share\doc\icu')
         self.install(bindir + r'\* bin')
         self.install(libdir + r'\* lib')

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -264,7 +264,7 @@ class Project_ffmpeg(Tarball, Project):
             self.add_dependency('x264')
 
     def build(self):
-        msys_path = os.path.join(self.builder.opts.msys_dir, 'usr', 'bin')
+        msys_path = Project.get_tool_path('msys2')
         self.exec_vs(r'%s\bash build\build.sh %s %s %s %s' % (msys_path, self.pkg_dir, self.builder.gtk_dir, self.builder.opts.configuration, "enable_gpl" if self.opts.ffmpeg_enable_gpl else "disable_gpl"),
                      add_path=msys_path)
 
@@ -1402,9 +1402,10 @@ class Project_openssl(Tarball, Project):
 
         # Note that we want to give priority to the system perl version.
         # Using the msys2 one might endup giving us a broken build
-        add_path = ';'.join([os.path.join(self.builder.perl_dir, 'bin'),
-                             os.path.join(self.builder.opts.msys_dir, 'usr', 'bin')])
-
+#        add_path = ';'.join([os.path.join(self.builder.perl_dir, 'bin'),
+#                             os.path.join(self.builder.opts.msys_dir, 'usr', 'bin')])
+        add_path = None
+        
         if self.builder.x86:
             self.exec_vs(r'%(perl_dir)s\bin\perl.exe Configure ' + debug_option + 'VC-WIN32 ' + common_options)
             self.exec_vs(r'ms\do_nasm', add_path=add_path)
@@ -1720,9 +1721,11 @@ class Project_x264(GitRepo, Project):
             patches = [ '0001-use-more-recent-version-of-config.guess.patch',
                         '0002-configure-recognize-the-msys-shell.patch' ]
             )
+
     def build(self):
-        self.exec_vs(r'%s\usr\bin\bash build\build.sh %s %s' % (self.builder.opts.msys_dir, convert_to_msys(self.builder.gtk_dir), self.builder.opts.configuration),
-                     add_path=os.path.join(self.builder.opts.msys_dir, 'usr', 'bin'))
+        msys_path = Project.get_tool_path('msys2')
+        self.exec_vs(r'%s\bash build\build.sh %s %s' % (msys_path, convert_to_msys(self.builder.gtk_dir), self.builder.opts.configuration),
+                     add_path=msys_path)
 
         # use the path expected when building with a dependent project
         self.builder.exec_msys(['mv', 'libx264.dll.lib', 'libx264.lib'], working_dir=os.path.join(self.builder.gtk_dir, 'lib'))

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -40,7 +40,7 @@ class Project_adwaita_icon_theme(Tarball, Project):
             'adwaita-icon-theme',
             archive_url = 'http://ftp.acc.umu.se/pub/GNOME/sources/adwaita-icon-theme/3.28/adwaita-icon-theme-3.28.0.tar.xz',
             hash = '7aae8c1dffd6772fd1a21a3d365a0ea28b7c3988bdbbeafbf8742cda68242150',
-            dependencies = ['librsvg'],
+            dependencies = ['librsvg', 'python', ],
             )
 
     def build(self):
@@ -602,11 +602,11 @@ class _MakeGir(object):
                 log.message('Unable to find detectenv-msvc.mak for %s' % (prj_name, ))
                 return
 
-        cmd = 'nmake -f %s-introspection-msvc.mak CFG=%s PREFIX=%s PYTHON=%s\python.exe install-introspection' % (
+        cmd = 'nmake -f %s-introspection-msvc.mak CFG=%s PREFIX=%s PYTHON=%s install-introspection' % (
                 prj_name,
                 self.builder.opts.configuration,
                 self.builder.gtk_dir,
-                self.builder.opts.python_dir,
+                Project.get_tool_executable('python'),
                 )
 
         self.push_location(b_dir)

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -818,7 +818,6 @@ class Project_icu(Tarball, Project):
             bindir += '64'
             libdir += '64'
 
-        self.push_location('.\icu')
         self.exec_msbuild(r'source\allinone\allinone.sln /t:cal')
 
         self.install(r'.\pc-files\* lib\pkgconfig')
@@ -826,8 +825,6 @@ class Project_icu(Tarball, Project):
         self.install(bindir + r'\* bin')
         self.install(libdir + r'\* lib')
         self.install(r'.\include\* include')
-
-        self.pop_location()
 
 @project_add
 class Project_jasper(Tarball, CmakeProject):

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -258,7 +258,7 @@ class Project_ffmpeg(Tarball, Project):
             'ffmpeg',
             archive_url = 'https://www.ffmpeg.org/releases/ffmpeg-4.1.1.tar.xz',
             hash = '373749824dfd334d84e55dff406729edfd1606575ee44dd485d97d45ea4d2d86',
-            dependencies = [ 'yasm', ],
+            dependencies = [ 'yasm', 'msys2', ],
         )
         if self.opts.ffmpeg_enable_gpl:
             self.add_dependency('x264')
@@ -571,7 +571,7 @@ class Project_gsettings_desktop_schemas(Tarball, Project):
             'gsettings-desktop-schemas',
             archive_url = 'http://ftp.acc.umu.se/pub/GNOME/sources/gsettings-desktop-schemas/3.24/gsettings-desktop-schemas-3.24.0.tar.xz',
             hash = 'f6573a3f661d22ff8a001cc2421d8647717f1c0e697e342d03c6102f29bbbb90',
-            dependencies = ['python', 'glib'],
+            dependencies = ['python', 'perl', 'glib'],
             patches = ['0001-build-win32-replace.py-Fix-replacing-items-in-files-.patch',
                        '0002-glib-mkenums-python.patch',
                        ],
@@ -1390,7 +1390,7 @@ class Project_openssl(Tarball, Project):
             'openssl',
             archive_url = 'https://www.openssl.org/source/openssl-1.0.2r.tar.gz',
             hash = 'ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6',
-            dependencies = ['perl', 'nasm', ],
+            dependencies = ['perl', 'nasm', 'msys2', ],
             )
 
     def build(self):
@@ -1715,7 +1715,7 @@ class Project_x264(GitRepo, Project):
             'x264',
             repo_url = 'http://git.videolan.org/git/x264.git',
             fetch_submodules = False,
-            dependencies = [ 'nasm' ],
+            dependencies = [ 'nasm', 'msys2' ],
             tag = 'e9a5903edf8ca59ef20e6f4894c196f135af735e',
             patches = [ '0001-use-more-recent-version-of-config.guess.patch',
                         '0002-configure-recognize-the-msys-shell.patch' ]

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -110,10 +110,10 @@ class Tool_nuget(Tool):
     def __init__(self):
         Tool.__init__(self,
             'nuget',
-            archive_url = 'https://dist.nuget.org/win-x86-commandline/v4.3.0/nuget.exe',
-            archive_file_name = 'nuget-4.3.0.exe',
-            hash = '386da77a8cf2b63d1260b7020feeedabfe3b65ab31d20e6a313a530865972f3a',
-            dir_part = 'nuget-4.3.0',
+            archive_url = 'https://dist.nuget.org/win-x86-commandline/v4.9.4/nuget.exe',
+            archive_file_name = 'nuget-4.9.4.exe',
+            hash = 'cb139d855d06d07e7da892e8558fe16dcaa65cb381175c506f5ed0a759eaf8f6',
+            dir_part = 'nuget-4.9.4',
             exe_name = 'nuget.exe')
 
     def unpack(self):

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -21,9 +21,12 @@ Default tools used to build the various projects
 
 import os
 import sys
+import subprocess
 
 from .utils.base_tool import Tool, tool_add
 from .utils.base_expanders import extract_exec
+from .utils.base_project import Project
+from .utils.simple_ui import log
 
 @tool_add
 class Tool_cmake(Tool):
@@ -51,7 +54,7 @@ class Tool_meson(Tool):
             archive_file_name = 'meson-0.50.0.zip',
             hash = '5e0447104a6400e108f7cdb2e71707924ccf986ac04a0cdc25300ddaa7863387',
             dependencies = [ 'python', ],
-            dir_part = 'meson-0.50.0', 
+            dir_part = 'meson-0.50.0',
             exe_name = 'meson.py')
 
     def unpack(self):
@@ -87,7 +90,7 @@ class Tool_nasm(Tool):
     def unpack(self):
         # We download directly the exe file so we copy it on the tool directory ...
         self.mark_deps = extract_exec(self.archive_file, self.builder.opts.tools_root_dir, dir_part = self.dir_part, check_file = self.full_exe, force_dest = self.full_exe, check_mark=True)
-    
+
 @tool_add
 class Tool_ninja(Tool):
     def __init__(self):
@@ -96,7 +99,7 @@ class Tool_ninja(Tool):
             archive_url = 'https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip',
             archive_file_name = 'ninja-win-1.8.2.zip',
             hash = 'c80313e6c26c0b9e0c241504718e2d8bbc2798b73429933adf03fdc6d84f0e70',
-            dir_part = 'ninja-1.8.2', 
+            dir_part = 'ninja-1.8.2',
             exe_name = 'ninja.exe')
 
     def unpack(self):
@@ -110,7 +113,7 @@ class Tool_nuget(Tool):
             archive_url = 'https://dist.nuget.org/win-x86-commandline/v4.3.0/nuget.exe',
             archive_file_name = 'nuget-4.3.0.exe',
             hash = '386da77a8cf2b63d1260b7020feeedabfe3b65ab31d20e6a313a530865972f3a',
-            dir_part = 'nuget-4.3.0', 
+            dir_part = 'nuget-4.3.0',
             exe_name = 'nuget.exe')
 
     def unpack(self):
@@ -124,7 +127,7 @@ class Tool_perl(Tool):
             'perl',
             archive_url = 'https://github.com/wingtk/gtk-win32/releases/download/Perl-5.20/perl-5.20.0-x64.tar.xz',
             hash = '05e01cf30bb47d3938db6169299ed49271f91c1615aeee5649174f48ff418c55',
-            dir_part = 'perl-5.20.0', 
+            dir_part = 'perl-5.20.0',
             )
 
     def load_defaults(self):
@@ -133,7 +136,7 @@ class Tool_perl(Tool):
         self.base_dir = os.path.join(self.build_dir, 'x64')
         # full path, added to the environment when needed
         self.tool_path = os.path.join(self.base_dir, 'bin')
-        self.full_exe = os.path.join(self.tool_path, 'perl.exe') 
+        self.full_exe = os.path.join(self.tool_path, 'perl.exe')
 
     def unpack(self):
         self.mark_deps = extract_exec(self.archive_file, self.build_dir, check_file = self.full_exe, check_mark=True)
@@ -145,20 +148,89 @@ class Tool_perl(Tool):
 class Tool_python(Tool):
     def __init__(self):
         Tool.__init__(self,
-            'python')
+            'python',
+            dependencies = [ 'nuget', ],
+            )
+
+    def setup(self, install):
+        """
+        Using nuget install, locally, the specified version of python
+        """
+        version = self.opts.python_ver;
+        # Get the last version we ask
+        if version == '3.5':
+            version = '3.5.4'
+        elif version == '3.6':
+            version = '3.6.8'
+        elif version == '3.7':
+            version = '3.7.3'
+
+        if self.opts.x86:
+            name = 'pythonx86'
+        else:
+            name = 'python'
+        t_id = name + '.' + version
+        dest_dir = os.path.join(self.opts.tools_root_dir, t_id)
+        # directory to use for the .exe
+        self.tool_path = os.path.join(dest_dir, 'tools')
+        self.full_exe = os.path.join(self.tool_path, 'python.exe')
+
+        if install:
+            # see if it's already ok
+            rd_file = ''
+            try:
+                with open(os.path.join(dest_dir, '.wingtk-extracted-file'), 'rt') as fi:
+                    rd_file = fi.readline().strip()
+            except IOError:
+                pass
+    
+            if rd_file == t_id:
+                # Ok, exit
+                log.log("Skipping python setup on '%s'" % (dest_dir, ))
+                # We don't rebuild the projects that depends on this
+                return False
+    
+            # nuget
+            nuget = Project.get_tool_executable('nuget')
+            # Install python
+            cmd = '%s install %s -Version %s -OutputDirectory %s' % (nuget, name, version, self.opts.tools_root_dir, )
+            subprocess.check_call(cmd, shell=True)
+            py = os.path.join(self.tool_path, 'python.exe')
+    
+            # Update pip
+            cmd = py + ' -m pip install --upgrade pip'
+            subprocess.check_call(cmd, shell=True)
+    
+            # update setuptools (to use vs2017 with python 3.5)
+            cmd = py + ' -m pip install --upgrade setuptools'
+            subprocess.check_call(cmd, shell=True)
+    
+            # install/update wheel
+            cmd = py + ' -m pip install --upgrade wheel --no-warn-script-location'
+            subprocess.check_call(cmd, shell=True)
+    
+            # Mark that we have done all
+            with open(os.path.join(dest_dir, '.wingtk-extracted-file'), 'wt') as fo:
+                fo.write('%s\n' % (t_id, ))
+
+        return True
 
     def load_defaults(self):
         Tool.load_defaults(self)
-        if self.opts.python_dir:
-            # From the command line, hope is at least 3.4 ...
-            self.tool_path = self.opts.python_dir
-        else:
-            # We use the one that call the script
-            self.tool_path = os.path.dirname(sys.executable)
-        self.full_exe = os.path.join(self.tool_path, 'python.exe')
+        self.setup(False)
 
     def unpack(self):
-        self.tool_mark()
+        if self.opts._load_python:
+            # Get python version
+            self.mark_deps = self.setup(True)
+        else:
+            if self.opts.python_dir:
+                # From the command line, hope is at least 3.4 ...
+                self.tool_path = self.opts.python_dir
+            else:
+                # We use the one that call the script
+                self.tool_path = os.path.dirname(sys.executable)
+            self.mark_deps = False
 
 @tool_add
 class Tool_yasm(Tool):
@@ -167,7 +239,7 @@ class Tool_yasm(Tool):
             'yasm',
             archive_url = 'http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe',
             hash = 'd160b1d97266f3f28a71b4420a0ad2cd088a7977c2dd3b25af155652d8d8d91f',
-            dir_part = 'yasm-1.3.0', 
+            dir_part = 'yasm-1.3.0',
             exe_name = 'yasm.exe')
 
     def unpack(self):

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -34,17 +34,13 @@ class Tool_cmake(Tool):
             hash = 'def3bb81dfd922ce1ea2a0647645eefb60e128d520c8ca707c5996c331bc8b48',
             dir_part = 'cmake-3.7.2-win64-x64')
 
-    def load_defaults(self, builder):
-        Tool.load_defaults(self, builder)
-        # Set the builder object to point to the file to use
-        self.cmake_path = self.build_dir
+    def load_defaults(self):
+        Tool.load_defaults(self)
+        self.tool_path = os.path.join(self.build_dir, 'bin')
+        self.full_exe = os.path.join(self.tool_path, 'cmake.exe')
 
     def unpack(self):
-        destfile = os.path.join(self.cmake_path, 'bin', 'cmake.exe')
-        self.mark_deps = extract_exec(self.archive_file, self.builder.opts.tools_root_dir, dir_part = self.dir_part, check_file = destfile, check_mark=True)
-
-    def get_path(self):
-        return os.path.join(self.cmake_path, 'bin')
+        self.mark_deps = extract_exec(self.archive_file, self.opts.tools_root_dir, dir_part = self.dir_part, check_file = self.full_exe, check_mark=True)
 
 @tool_add
 class Tool_meson(Tool):
@@ -54,20 +50,12 @@ class Tool_meson(Tool):
             archive_url = 'https://github.com/mesonbuild/meson/archive/0.50.0.zip',
             archive_file_name = 'meson-0.50.0.zip',
             hash = '5e0447104a6400e108f7cdb2e71707924ccf986ac04a0cdc25300ddaa7863387',
-            dir_part = 'meson-0.50.0',
             dependencies = [ 'python', ],
-            )
-
-    def load_defaults(self, builder):
-        Tool.load_defaults(self, builder)
-        # Set the builder object to point to the file to use
-        builder.meson = os.path.join(self.build_dir, 'meson.py')
+            dir_part = 'meson-0.50.0', 
+            exe_name = 'meson.py')
 
     def unpack(self):
-        self.mark_deps = extract_exec(self.archive_file, self.builder.opts.tools_root_dir, dir_part = self.dir_part, check_file = self.builder.meson, check_mark=True)
-
-    def get_path(self):
-        return None, self.build_dir
+        self.mark_deps = extract_exec(self.archive_file, self.builder.opts.tools_root_dir, dir_part = self.dir_part, check_file = self.full_exe, check_mark=True)
 
 @tool_add
 class Tool_msys2(Tool):
@@ -75,19 +63,16 @@ class Tool_msys2(Tool):
         Tool.__init__(self,
             'msys2')
 
-    def load_defaults(self, builder):
-        Tool.load_defaults(self, builder)
-        self.msys_path = os.path.join(builder.opts.msys_dir, 'usr', 'bin')
+    def load_defaults(self):
+        Tool.load_defaults(self)
+        self.tool_path = os.path.join(self.opts.msys_dir, 'usr', 'bin')
 
     def unpack(self):
-        # Create the directory to let the --fast-build option work as expected
-        if not os.path.exists(self.build_dir):
-            os.makedirs(self.build_dir)
-            self.mark_deps = True
+        self.tool_mark()
 
     def get_path(self):
         # We always put msys at the end of path
-        return None, self.msys_path
+        return None, self.tool_path
 
 @tool_add
 class Tool_nasm(Tool):
@@ -96,20 +81,13 @@ class Tool_nasm(Tool):
             'nasm',
             archive_url = 'https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/win64/nasm-2.13.03-win64.zip',
             hash = 'b3a1f896b53d07854884c2e0d6be7defba7ebd09b864bbb9e6d69ada1c3e989f',
-            dir_part = 'nasm-2.13.03')
-
-    def load_defaults(self, builder):
-        Tool.load_defaults(self, builder)
-        self.nasm_path = self.build_dir
+            dir_part = 'nasm-2.13.03',
+            exe_name = 'nasm.exe')
 
     def unpack(self):
         # We download directly the exe file so we copy it on the tool directory ...
-        destfile = os.path.join(self.build_dir, 'nasm.exe')
-        self.mark_deps = extract_exec(self.archive_file, self.builder.opts.tools_root_dir, dir_part = self.dir_part, check_file = destfile, force_dest = destfile, check_mark=True)
-
-    def get_path(self):
-        return self.nasm_path
-
+        self.mark_deps = extract_exec(self.archive_file, self.builder.opts.tools_root_dir, dir_part = self.dir_part, check_file = self.full_exe, force_dest = self.full_exe, check_mark=True)
+    
 @tool_add
 class Tool_ninja(Tool):
     def __init__(self):
@@ -117,19 +95,11 @@ class Tool_ninja(Tool):
             'ninja',
             archive_url = 'https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip',
             archive_file_name = 'ninja-win-1.8.2.zip',
-            hash = 'c80313e6c26c0b9e0c241504718e2d8bbc2798b73429933adf03fdc6d84f0e70')
-
-    def load_defaults(self, builder):
-        Tool.load_defaults(self, builder)
-        # Set the builder object to point to the path to use
-        self.ninja_path = self.build_dir
+            hash = 'c80313e6c26c0b9e0c241504718e2d8bbc2798b73429933adf03fdc6d84f0e70',
+            exe_name = 'ninja.exe')
 
     def unpack(self):
-        destfile = os.path.join(self.ninja_path, 'ninja.exe')
-        self.mark_deps = extract_exec(self.archive_file, self.ninja_path, check_file = destfile, check_mark=True)
-
-    def get_path(self):
-        return self.ninja_path
+        self.mark_deps = extract_exec(self.archive_file, self.build_dir, check_file = self.full_exe, check_mark=True)
 
 @tool_add
 class Tool_nuget(Tool):
@@ -138,20 +108,12 @@ class Tool_nuget(Tool):
             'nuget',
             archive_url = 'https://dist.nuget.org/win-x86-commandline/v4.3.0/nuget.exe',
             archive_file_name = 'nuget-4.3.0.exe',
-            hash = '386da77a8cf2b63d1260b7020feeedabfe3b65ab31d20e6a313a530865972f3a')
-
-    def load_defaults(self, builder):
-        Tool.load_defaults(self, builder)
-        # Set the builder object to point to the .exe file to use
-        builder.nuget = os.path.join(self.build_dir, 'nuget.exe')
+            hash = '386da77a8cf2b63d1260b7020feeedabfe3b65ab31d20e6a313a530865972f3a',
+            exe_name = 'nuget.exe')
 
     def unpack(self):
         # We download directly the exe file so we copy it on the tool directory ...
-        self.mark_deps = extract_exec(self.archive_file, self.build_dir, check_file = self.builder.nuget, force_dest = self.builder.nuget, check_mark=True)
-
-    def get_path(self):
-        # No need to add the path, we use the full file name
-        pass
+        self.mark_deps = extract_exec(self.archive_file, self.build_dir, check_file = self.full_exe, force_dest = self.full_exe, check_mark=True)
 
 @tool_add
 class Tool_perl(Tool):
@@ -161,20 +123,19 @@ class Tool_perl(Tool):
             archive_url = 'https://github.com/wingtk/gtk-win32/releases/download/Perl-5.20/perl-5.20.0-x64.tar.xz',
             hash = '05e01cf30bb47d3938db6169299ed49271f91c1615aeee5649174f48ff418c55')
 
-    def load_defaults(self, builder):
-        Tool.load_defaults(self, builder)
-        # Set the builder object to point to the path to use, when we need to pass directly
-        # the executable to *make
-        builder.perl_dir = os.path.join(self.build_dir, 'x64')
+    def load_defaults(self):
+        Tool.load_defaults(self)
+        # Set the builder object to point to the path to use, when we need to pass directly the executable to *make
+        self.base_dir = os.path.join(self.build_dir, 'x64')
         # full path, added to the environment when needed
-        self.perl_path = os.path.join(builder.perl_dir, 'bin')
+        self.tool_path = os.path.join(self.base_dir, 'bin')
+        self.full_exe = os.path.join(self.tool_path, 'perl.exe') 
 
     def unpack(self):
-        destfile = os.path.join(self.perl_path, 'perl.exe')
-        self.mark_deps = extract_exec(self.archive_file, self.build_dir, check_file = destfile, check_mark=True)
+        self.mark_deps = extract_exec(self.archive_file, self.build_dir, check_file = self.full_exe, check_mark=True)
 
-    def get_path(self):
-        return self.perl_path
+    def get_base_dir(self):
+        return self.base_dir
 
 @tool_add
 class Tool_python(Tool):
@@ -182,23 +143,18 @@ class Tool_python(Tool):
         Tool.__init__(self,
             'python')
 
-    def load_defaults(self, builder):
-        Tool.load_defaults(self, builder)
-        if builder.opts.python_dir:
+    def load_defaults(self):
+        Tool.load_defaults(self)
+        if self.opts.python_dir:
             # From the command line, hope is at least 3.4 ...
-            self.python_path = builder.opts.python_dir
+            self.tool_path = self.opts.python_dir
         else:
             # We use the one that call the script
-            self.python_path = os.path.dirname(sys.executable)
+            self.tool_path = os.path.dirname(sys.executable)
+        self.full_exe = os.path.join(self.tool_path, 'python.exe')
 
     def unpack(self):
-        # Create the directory to let the --fast-build option work as expected
-        if not os.path.exists(self.build_dir):
-            os.makedirs(self.build_dir)
-            self.mark_deps = True
-
-    def get_path(self):
-        return self.python_path
+        self.tool_mark()
 
 @tool_add
 class Tool_yasm(Tool):
@@ -206,19 +162,12 @@ class Tool_yasm(Tool):
         Tool.__init__(self,
             'yasm',
             archive_url = 'http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe',
-            hash = 'd160b1d97266f3f28a71b4420a0ad2cd088a7977c2dd3b25af155652d8d8d91f')
-
-    def load_defaults(self, builder):
-        Tool.load_defaults(self, builder)
-        self.yasm_path = self.build_dir
+            hash = 'd160b1d97266f3f28a71b4420a0ad2cd088a7977c2dd3b25af155652d8d8d91f',
+            exe_name = 'yasm.exe')
 
     def unpack(self):
         # We download directly the exe file so we copy it on the tool directory ...
-        destfile = os.path.join(self.build_dir, 'yasm.exe')
-        self.mark_deps = extract_exec(self.archive_file, self.build_dir, check_file = destfile, force_dest = destfile, check_mark=True)
-
-    def get_path(self):
-        return self.yasm_path
+        self.mark_deps = extract_exec(self.archive_file, self.build_dir, check_file = self.full_exe, force_dest = self.full_exe, check_mark=True)
 
 @tool_add
 class Tool_go(Tool):
@@ -226,17 +175,15 @@ class Tool_go(Tool):
         Tool.__init__(self,
             'go',
             archive_url = 'https://dl.google.com/go/go1.10.windows-amd64.zip',
-            hash = '210b223031c254a6eb8fa138c3782b23af710a9959d64b551fa81edd762ea167')
+            hash = '210b223031c254a6eb8fa138c3782b23af710a9959d64b551fa81edd762ea167',
+            dir_part = 'go-1.10',
+            )
 
-    def load_defaults(self, builder):
-        Tool.load_defaults(self, builder)
-        self.go_dir = os.path.join(self.build_dir, 'go')
-        self.go_path = os.path.join(self.go_dir, 'bin')
+    def load_defaults(self):
+        Tool.load_defaults(self)
+        self.tool_path = os.path.join(self.build_dir, 'bin')
+        self.full_exe = os.path.join(self.tool_path, 'go.exe')
 
     def unpack(self):
         # We download directly the exe file so we copy it on the tool directory ...
-        destfile = os.path.join(self.go_path, 'go.exe')
-        self.mark_deps = extract_exec(self.archive_file, self.build_dir, check_file = destfile, check_mark=True)
-
-    def get_path(self):
-        return self.go_path
+        self.mark_deps = extract_exec(self.archive_file, self.build_dir, check_file = self.full_exe, check_mark=True, strip_one=True)

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -54,7 +54,9 @@ class Tool_meson(Tool):
             archive_url = 'https://github.com/mesonbuild/meson/archive/0.50.0.zip',
             archive_file_name = 'meson-0.50.0.zip',
             hash = '5e0447104a6400e108f7cdb2e71707924ccf986ac04a0cdc25300ddaa7863387',
-            dir_part = 'meson-0.50.0')
+            dir_part = 'meson-0.50.0',
+            dependencies = [ 'python', ],
+            )
 
     def load_defaults(self, builder):
         Tool.load_defaults(self, builder)

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -96,6 +96,7 @@ class Tool_ninja(Tool):
             archive_url = 'https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip',
             archive_file_name = 'ninja-win-1.8.2.zip',
             hash = 'c80313e6c26c0b9e0c241504718e2d8bbc2798b73429933adf03fdc6d84f0e70',
+            dir_part = 'ninja-1.8.2', 
             exe_name = 'ninja.exe')
 
     def unpack(self):
@@ -109,6 +110,7 @@ class Tool_nuget(Tool):
             archive_url = 'https://dist.nuget.org/win-x86-commandline/v4.3.0/nuget.exe',
             archive_file_name = 'nuget-4.3.0.exe',
             hash = '386da77a8cf2b63d1260b7020feeedabfe3b65ab31d20e6a313a530865972f3a',
+            dir_part = 'nuget-4.3.0', 
             exe_name = 'nuget.exe')
 
     def unpack(self):
@@ -121,7 +123,9 @@ class Tool_perl(Tool):
         Tool.__init__(self,
             'perl',
             archive_url = 'https://github.com/wingtk/gtk-win32/releases/download/Perl-5.20/perl-5.20.0-x64.tar.xz',
-            hash = '05e01cf30bb47d3938db6169299ed49271f91c1615aeee5649174f48ff418c55')
+            hash = '05e01cf30bb47d3938db6169299ed49271f91c1615aeee5649174f48ff418c55',
+            dir_part = 'perl-5.20.0', 
+            )
 
     def load_defaults(self):
         Tool.load_defaults(self)
@@ -163,6 +167,7 @@ class Tool_yasm(Tool):
             'yasm',
             archive_url = 'http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe',
             hash = 'd160b1d97266f3f28a71b4420a0ad2cd088a7977c2dd3b25af155652d8d8d91f',
+            dir_part = 'yasm-1.3.0', 
             exe_name = 'yasm.exe')
 
     def unpack(self):

--- a/gvsbuild/utils/base_builders.py
+++ b/gvsbuild/utils/base_builders.py
@@ -63,7 +63,9 @@ class Meson(Project):
             if meson_params:
                 add_opts += ' ' + meson_params
             # pyhon meson.py src_dir ninja_build_dir --prefix gtk_bin options
-            cmd = '%s\\python.exe %s %s %s --prefix %s %s' % (self.builder.opts.python_dir, self.builder.meson, self._get_working_dir(), ninja_build, self.builder.gtk_dir, add_opts, )
+            meson = Project.get_tool_executable('meson')
+            python = Project.get_tool_executable('python')
+            cmd = '%s %s %s %s --prefix %s %s' % (python, meson, self._get_working_dir(), ninja_build, self.builder.gtk_dir, add_opts, )
             # build the ninja file to do everything (build the library, create the .pc file, install it, ...)
             self.exec_vs(cmd)
             log.end()

--- a/gvsbuild/utils/base_expanders.py
+++ b/gvsbuild/utils/base_expanders.py
@@ -235,11 +235,11 @@ class GitRepo(object):
         if self.tag:
             self.builder.exec_msys('git checkout -f %s' % self.tag, working_dir=self.build_dir)
 
-        self.create_zip()
         if self.fetch_submodules:
             log.start_verbose('Fetch submodule(s)')
             self.builder.exec_msys('git submodule update --init',  working_dir=self.build_dir)
             log.end()
+        self.create_zip()
         log.end()
 
     def update_build_dir(self):
@@ -255,11 +255,11 @@ class GitRepo(object):
             self.builder.exec_msys('git checkout -f', working_dir=self.build_dir)
             self.builder.exec_msys('git pull --rebase', working_dir=self.build_dir)
 
-        self.create_zip()
         if self.fetch_submodules:
             log.start_verbose('Update submodule(s)')
             self.builder.exec_msys('git submodule update --init', working_dir=self.build_dir)
             log.end()
+        self.create_zip()
 
         if os.path.exists(self.patch_dir):
             log.log("Copying files from %s to %s" % (self.patch_dir, self.build_dir))

--- a/gvsbuild/utils/base_expanders.py
+++ b/gvsbuild/utils/base_expanders.py
@@ -108,7 +108,18 @@ def extract_exec(src, dest_dir, dir_part=None, strip_one=False, check_file=None,
     elif ext == '.zip':
         # Zip file
         with zipfile.ZipFile(src) as zf:
-            zf.extractall(path=dest_dir)
+            if strip_one:
+                members = zf.infolist()
+                for m in members:
+                    if m.is_dir():
+                        continue
+                    cl = m.filename.split('/')
+                    if len(cl) > 1:
+                        m.filename = '/'.join(cl[1:])
+                        
+                    zf.extract(m, path=dest_dir)
+            else:
+                zf.extractall(path=dest_dir)
     else:
         # Ok, hoping it's a tarfile we can handle :)
         with tarfile.open(src) as tar:

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -39,6 +39,8 @@ class Options(object):
         self.enable_gi = False
         self.gtk3_ver = '3.22'
         self.ffmpeg_enable_gpl = False
+        # Default
+        self._load_python = False
 
 class Project(object):
     def __init__(self, name, **kwargs):

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -79,7 +79,7 @@ class Project(object):
     def __repr__(self):
         return repr(self.name)
 
-    def load_defaults(self, builder):
+    def load_defaults(self):
         # Used by the tools to load default paths/filenames
         pass
     
@@ -263,10 +263,11 @@ class Project(object):
         return dict(Project._dict)
 
     @staticmethod
-    def get_tool_path(tool_name):
-        p = Project._dict[tool_name]
-        if p.type == GVSBUILD_TOOL:
-            t = p.get_path()
+    def get_tool_path(tool):
+        if not isinstance(tool, Project):
+            tool = Project._dict[tool]
+        if tool.type == GVSBUILD_TOOL:
+            t = tool.get_path()
             if isinstance(t, tuple):
                 # Get the one that's not null
                 return t[0] if t[0] else t[1]
@@ -274,6 +275,24 @@ class Project(object):
                 return t
         else:
             return None
+
+    @staticmethod
+    def get_tool_executable(tool):
+        if not isinstance(tool, Project):
+            tool = Project._dict[tool]
+            
+        if tool.type == GVSBUILD_TOOL:
+            return tool.get_executable()
+        return None
+
+    @staticmethod
+    def get_tool_base_dir(tool):
+        if not isinstance(tool, Project):
+            tool = Project._dict[tool]
+            
+        if tool.type == GVSBUILD_TOOL:
+            return tool.get_base_dir()
+        return None
 
     @staticmethod
     def _file_to_version(file_name):

--- a/gvsbuild/utils/base_tool.py
+++ b/gvsbuild/utils/base_tool.py
@@ -61,7 +61,7 @@ class Tool(Project):
     def get_executable(self):
         if self.full_exe:
             return self.full_exe
-        raise NotImplementedError('get_executable')
+        raise NotImplementedError('%s:get_executable' % (self.name, ))
     
     def get_base_dir(self):
         '''

--- a/gvsbuild/utils/base_tool.py
+++ b/gvsbuild/utils/base_tool.py
@@ -27,14 +27,24 @@ class Tool(Project):
     def __init__(self, name, **kwargs):
         self.dir_part = None
         self.mark_deps = False 
+        self.tool_path = None
+        self.full_exe = None
         Project.__init__(self, name, **kwargs)
 
-    def load_defaults(self, builder):
+    def load_defaults(self):
         if self.dir_part:
-            self.build_dir = os.path.join(builder.opts.tools_root_dir, self.dir_part)
+            self.build_dir = os.path.join(self.opts.tools_root_dir, self.dir_part)
         else:
-            self.build_dir = os.path.join(builder.opts.tools_root_dir, self.name)
+            self.build_dir = os.path.join(self.opts.tools_root_dir, self.name)
+        if hasattr(self, 'exe_name'):
+            self.full_exe = os.path.join(self.build_dir, self.exe_name)
 
+    def tool_mark(self):
+        # Create the directory to let the --fast-build option work as expected
+        if not os.path.exists(self.build_dir):
+            os.makedirs(self.build_dir)
+            self.mark_deps = True
+        
     def build(self):
         # All the work is done in the unpack & we don't force the rebuild of all projects that uses this tool
         return not self.mark_deps
@@ -43,8 +53,23 @@ class Tool(Project):
         self.unpack()
 
     def get_path(self):
-        # Mandatory for tools
-        raise NotImplementedError("get_path")
+        if self.tool_path:
+            return self.tool_path
+        else:
+            return self.build_dir
+
+    def get_executable(self):
+        if self.full_exe:
+            return self.full_exe
+        raise NotImplementedError('get_executable')
+    
+    def get_base_dir(self):
+        '''
+        Base directory for the tool, used for perl to have the dir to pass to the *make
+        tool, normally not used (we update the path or use directly the executable)
+        '''
+        raise NotImplementedError('get_base_dir')
+        
 
 def tool_add(cls):
     """

--- a/patches/icu/pc-files/icu-uc.pc
+++ b/patches/icu/pc-files/icu-uc.pc
@@ -1,0 +1,12 @@
+# On windows, the prefix is automagically build from the location of the .pc file
+prefix=C:/dir_placeholder
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: icu-uc
+Description: International Components for Unicode: Common and Data libraries
+Version: 63.1
+
+Libs: -L${libdir} -licuuc -licudt
+Cflags: -I${includedir}/unicode


### PR DESCRIPTION

The main change is the automatic download & update, with nuget, of the python (3.5, 3.6, 3.7) to use for the projects.
This means that the python use to launch the scripts is not touched (if you build the pycairo it was installed in that python site-packages dir) and you can use also the embedded version, downloaded as a .zip file, without the need to install anything system wide for python.