### PR TITLE
fix --same-python and --python-dir not being honored

### DIFF
--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -230,6 +230,7 @@ class Tool_python(Tool):
             else:
                 # We use the one that call the script
                 self.tool_path = os.path.dirname(sys.executable)
+            self.full_exe = os.path.join(self.tool_path, 'python.exe')
             self.mark_deps = False
 
 @tool_add


### PR DESCRIPTION
Currently --same-python and --python-dir are not honored by the script due to self.full_exe not being updated after self.tool_path was.

```
python .\build.py build -p x64 --python-dir d:\Python36 --msys-dir d:\msys64 --vs-install-path d:\VS2017 --build-dir d:\deluge-build\gtk-build --vs-ver 15 gtk3

Cleaning up the build environment
Checking msys tool
Checking Msvc tool
Downloading packages
Building project ninja (1.8.2)
Building project nuget (4.9.4)
Building project python ()
Building project meson (0.50.0)
Building project pkg-config (git/pkgconf-1.5.4)
(git) Updating directory d:\deluge-build\gtk-build\build\x64\release\pkgconf
Removing 0001-vs2013.patch
Removing 0001-vs2013.patch.patch-applied
HEAD is now at 74133ed pkgconf 1.5.4.
patching file libpkgconf/bsdstubs.c
patching file libpkgconf/libpkgconf.h
The system cannot find the path specified.
Traceback (most recent call last):
  File "D:\deluge-build\gvsbuild\gvsbuild\utils\builder.py", line 477, in build
    if self.__build_one(p):
  File "D:\deluge-build\gvsbuild\gvsbuild\utils\builder.py", line 599, in __build_one
    skip_deps = proj.build()
  File "D:\deluge-build\gvsbuild\gvsbuild\projects.py", line 1548, in build
    Meson.build(self)
  File "D:\deluge-build\gvsbuild\gvsbuild\utils\base_builders.py", line 70, in build
    self.exec_vs(cmd)
  File "D:\deluge-build\gvsbuild\gvsbuild\utils\base_project.py", line 108, in exec_vs
    self.builder.exec_vs(cmd, working_dir=self._get_working_dir(), add_path=add_path)
  File "D:\deluge-build\gvsbuild\gvsbuild\utils\builder.py", line 839, in exec_vs
    self.__execute(self.__sub_vars(cmd), working_dir=working_dir, add_path=add_path, env=self.vs_env)
  File "D:\deluge-build\gvsbuild\gvsbuild\utils\builder.py", line 879, in __execute
    subprocess.check_call(args, cwd=working_dir, env=env, shell=True)
  File "D:\Python36\lib\subprocess.py", line 311, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'd:\deluge-build\gtk-build\tools\python.3.7.3\tools\python.exe d:\deluge-build\gtk-build\tools\meson-0.50.0\meson.py d:\deluge-build\gtk-build\build\x64\release\pkgconf d:\deluge-build\gtk-build\build\x64\release\pkgconf-meson --prefix d:\deluge-build\gtk-build\gtk\x64\release -Dtests=false --buildtype release' returned non-zero exit status 1.
Error: pkg-config build failed
```

This PR fixes the issue.