### PR TITLE
gobject-introspection: cairo-libname -> cairo_libname

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -514,7 +514,7 @@ class Project_gobject_introspection(Tarball, Meson):
             log.debug("Python library path is [%s]" % (py_libs, ))
             self.builder.mod_env('LIB', py_libs, prepend=False)
 
-        Meson.build(self, meson_params='-Dpython=%s\\python.exe -Dcairo-libname=cairo-gobject.dll' % (py_dir, ))
+        Meson.build(self, meson_params='-Dpython=%s\\python.exe -Dcairo_libname=cairo-gobject.dll' % (py_dir, ))
 
 @project_add
 class Project_graphene(GitRepo, Meson):


### PR DESCRIPTION
The option name was changed upstream between 1.58 and 1.60.

https://gitlab.gnome.org/GNOME/gobject-introspection/commit/b788f975b3ca7f092c

Fixes #243