### PR TITLE
builder: add echo before command to run vcvars.bat

### DIFF
--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -325,7 +325,7 @@ class Builder(object):
             else:
                 return None
 
-        output = subprocess.check_output('cmd.exe /c ""%s"%s>NUL && set"' % (vcvars_bat, add_opts, ), shell=True)
+        output = subprocess.check_output('echo cmd.exe /c ""%s"%s>NUL && set"' % (vcvars_bat, add_opts, ), shell=True)
         return output
 
     def __check_vs(self, opts):


### PR DESCRIPTION
Without the echo, the backticks are included in the command, which then fails. 
See https://github.com/wingtk/gvsbuild/issues/333