### PR TITLE
Add rust/cargo build support

### DIFF
--- a/gvsbuild/groups.py
+++ b/gvsbuild/groups.py
@@ -29,6 +29,7 @@ class Group_Tools(Group):
         Group.__init__(self,
             'tools',
             dependencies = [
+                'cargo',
                 'cmake',
                 'go',
                 'meson',

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -31,7 +31,8 @@ from .utils.base_expanders import Tarball, GitRepo
 from .utils.base_expanders import NullExpander
 from .utils.base_project import Project, project_add
 from .utils.base_project import GVSBUILD_IGNORE
-from .utils.base_builders import Meson, MercurialCmakeProject, CmakeProject
+from .utils.base_builders import Meson, MercurialCmakeProject, CmakeProject, Rust
+
 
 @project_add
 class Project_adwaita_icon_theme(Tarball, Project):
@@ -176,6 +177,28 @@ class Project_cyrus_sasl(Tarball, Project):
                      r'LMDB_LIBPATH="%(gtk_dir)s\lib" OPENSSL_INCLUDE="%(gtk_dir)s\include" OPENSSL_LIBPATH="%(gtk_dir)s\lib" prefix="%(pkg_dir)s" CFG=' + configuration)
 
         self.install(r'.\COPYING share\doc\cyrus-sasl')
+
+
+@project_add
+class Project_dcv_color_primitives(GitRepo, Rust):
+    def __init__(self):
+        Rust.__init__(self,
+            'dcv-color-primitives',
+            repo_url = 'https://github.com/aws/dcv-color-primitives.git',
+            fetch_submodules = False,
+            tag = None,
+            dependencies = [
+                'cargo',
+            ],
+            )
+
+    def build(self):
+        Rust.build(self, make_tests=True)
+
+        self.install(r'.\cargo-build\lib\dcv_color_primitives.lib lib')
+        self.install(r'.\include\dcv_color_primitives.h include\dcv-color-primitives')
+        self.install(r'.\LICENSE share\doc\dcv-color-primitives')
+
 
 @project_add
 class Project_emeus(GitRepo, Meson):

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -29,6 +29,36 @@ from .utils.base_project import Project
 from .utils.simple_ui import log
 
 @tool_add
+class Tool_cargo(Tool):
+    def __init__(self):
+        Tool.__init__(self,
+            'cargo',
+            archive_url = 'https://win.rustup.rs/x86_64',
+            archive_file_name = 'rustup-init.exe',
+            exe_name = 'cargo.exe')
+
+    def load_defaults(self):
+        Tool.load_defaults(self)
+        self.tool_path = os.path.join(self.build_dir, 'bin')
+        self.full_exe = os.path.join(self.tool_path, 'cargo.exe')
+
+    def unpack(self):
+        env = os.environ.copy()
+        env['RUSTUP_HOME'] = self.build_dir
+        env['CARGO_HOME'] = self.build_dir
+
+        rustup = os.path.join(self.build_dir, 'bin', 'rustup.exe')
+
+        subprocess.check_call('%s -y' % self.archive_file, shell=True, env=env)
+
+        # add supported targets
+        subprocess.check_call('%s target add x86_64-pc-windows-msvc' % rustup, shell=True, env=env)
+        subprocess.check_call('%s target add i686-pc-windows-msvc' % rustup, shell=True, env=env)
+
+        self.mark_deps = True
+
+
+@tool_add
 class Tool_cmake(Tool):
     def __init__(self):
         Tool.__init__(self,

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -39,8 +39,8 @@ class Tool_cargo(Tool):
 
     def load_defaults(self):
         Tool.load_defaults(self)
-        self.tool_path = os.path.join(self.build_dir, 'bin')
-        self.full_exe = os.path.join(self.tool_path, 'cargo.exe')
+        self.tool_path = os.path.join(self.build_dir)
+        self.full_exe = os.path.join(self.tool_path, 'bin', 'cargo.exe')
 
     def unpack(self):
         env = os.environ.copy()
@@ -54,7 +54,7 @@ class Tool_cargo(Tool):
         # add supported targets
         subprocess.check_call('%s target add x86_64-pc-windows-msvc' % rustup, shell=True, env=env)
         subprocess.check_call('%s target add i686-pc-windows-msvc' % rustup, shell=True, env=env)
-
+        
         self.mark_deps = True
 
 

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -49,7 +49,7 @@ class Tool_cargo(Tool):
 
         rustup = os.path.join(self.build_dir, 'bin', 'rustup.exe')
 
-        subprocess.check_call('%s -y' % self.archive_file, shell=True, env=env)
+        subprocess.check_call('%s --no-modify-path -y' % self.archive_file, shell=True, env=env)
 
         # add supported targets
         subprocess.check_call('%s target add x86_64-pc-windows-msvc' % rustup, shell=True, env=env)

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -839,6 +839,21 @@ class Builder(object):
     def exec_vs(self, cmd, working_dir=None, add_path=None):
         self.__execute(self.__sub_vars(cmd), working_dir=working_dir, add_path=add_path, env=self.vs_env)
 
+    def exec_cargo(self, params='', working_dir=None, rustc_opts=None):
+        cmd = 'cargo'
+        if self.opts.cargo_opts:
+            cmd += ' ' + self.opts.cargo_opts
+        if params:
+            cmd += ' ' + params
+
+        if rustc_opts is not None:
+            env = os.environ.copy().update(rustc_opts)
+        else:
+            env = os.environ
+
+        cargo_home = Project.get_tool_path('cargo')
+        self.__execute(self.__sub_vars(cmd), working_dir=working_dir, add_path=cargo_home, env=env)
+
     def exec_cmd(self, cmd, working_dir=None, add_path=None):
         self.__execute(self.__sub_vars(cmd), working_dir=working_dir, add_path=add_path)
 

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -65,6 +65,7 @@ def get_options(args):
     opts.ffmpeg_enable_gpl = args.ffmpeg_enable_gpl
     opts.log_size = args.log_size
     opts.log_single = args.log_single
+    opts.cargo_opts = args.cargo_opts
     opts.ninja_opts = args.ninja_opts
     opts.python_ver = args.python_ver
     opts.same_python = args.same_python
@@ -301,6 +302,8 @@ Examples:
                          help="Always start a new log file, with date & time")
     p_build.add_argument('--ninja-opts', default='',
                          help='Command line options to pass to ninja, e.g. to limit the use (-j 2) or for debug purpouse.')
+    p_build.add_argument('--cargo-opts', default='',
+                         help='Command line options to pass to cargo.')
 
     p_build.add_argument('project', nargs='+',
                          help='Project(s) to build.')


### PR DESCRIPTION
Added support to build rust crates.

**Added tools**
`Tool_cargo`: This tool is the rust package manager/builder. The latest stable version of rust is downloaded and installed. In order to support both 32 and 64 bits builds, both `x86_64-pc-windows-msvc` and `i686-pc-windows-msvc` are installed.

**Added base builders**
`Rust`: Rust project builder. Handles:
* build platform (32/64 bits)
* build type (debug/release). **Note**: in rust a release build, unless specified, will not contain debug symbols. Since we do want a release with debug symbols, we request this adding `-g` to `RUSTFLAGS` enviroment variable
* commands: clean/build/test
* per-project provided cargo params `cargo_params`
* global provided params `cargo_opts` 

**Added projects**
`Dcv-color-primitives`: a rust library to perform color conversion. https://github.com/aws/dcv-color-primitives