### PR TITLE
Option --capture-out to redirect the build output to the log file

### DIFF
--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -69,6 +69,8 @@ def get_options(args):
     opts.ninja_opts = args.ninja_opts
     opts.python_ver = args.python_ver
     opts.same_python = args.same_python
+    opts.capture_out = args.capture_out
+    opts.print_out = args.print_out
 
     # active the log
     log.configure(os.path.join(opts.build_dir, 'logs'), opts)
@@ -300,6 +302,10 @@ Examples:
                          help="Maximum log size (in kilobytes) before restarting with a new file")
     p_build.add_argument('--log-single', default=False, action='store_true',
                          help="Always start a new log file, with date & time")
+    p_build.add_argument('--capture-out', default=False, action='store_true',
+                         help="Capture the output of the build process and put it in the log file.")
+    p_build.add_argument('--print-out', default=False, action='store_true',
+                         help="With --capture-out acrive print the result of the commands also on stdout.")
     p_build.add_argument('--ninja-opts', default='',
                          help='Command line options to pass to ninja, e.g. to limit the use (-j 2) or for debug purpouse.')
     p_build.add_argument('--cargo-opts', default='',

--- a/gvsbuild/utils/simple_ui.py
+++ b/gvsbuild/utils/simple_ui.py
@@ -85,6 +85,7 @@ class Log(object):
                 self.level = LOG_VERBOSE
             max_size_kb = opts.log_size
             single = opts.log_single
+            self.capture = opts.capture_out
             if single:
                 max_size_kb = 0
 
@@ -161,7 +162,10 @@ class Log(object):
         if enabled:
             print(msg)
             self._indend_check()
-        
+
+        if self.capture:
+            self._output(msg, check_indent=False)
+
         co = LogElem(msg, enabled)
         self.operations.append(co)
 
@@ -218,6 +222,26 @@ class Log(object):
             # already printed
             return
         print(msg)
+
+    def messages_dump(self, msgs, prt=False, err=None):
+        if err is not None:
+            if not err:
+                err = 'Attention! Error presents!'
+            self.message(err)
+            self.message('')
+            # with error we want to know what's happeninh
+            prt = True
+
+        lines = msgs.split('\n')
+        lines = [l.rstrip() for l in lines if l.rstrip() != '']
+        if self.fo:
+            # On the file, if active
+            for l in lines:
+                self.fo.write('    %s\n' % (l, ))
+        
+        if prt:
+            for l in lines:
+                print(l) 
 
     def log(self, msg):
         if self._verbose:


### PR DESCRIPTION
With also --print-out the output is printed, at end of the built of the single
project, also on the consolle.