### PR TITLE
Update docs and help to specify Visual Studio 2019 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ $env:Path = "C:\gtk-build\gtk\x64\release\bin;" + $env:Path
 
 #### Other Options
 
- To build the 64-bit version with the Visual Studio 2017 (version 15) you need
+ To build the 64-bit version with the Visual Studio 2019 (version 16) you need
  also to tell the script the visual studio version, run:
 
  ```
  cd C:\gtk-build\github\gvsbuild
- python .\build.py build -p x64 --vs-ver 15 gtk3
+ python .\build.py build -p x64 --vs-ver 16 gtk3
  ```
 
  For more information about the possible commands run:

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -246,7 +246,7 @@ Examples:
     p_build.add_argument('--tools-root-dir',
                          help="The directory where to install the downloaded tools. Default is $(build-dir)\\tools.")
     p_build.add_argument('--vs-ver', default='12',
-                         help="Visual Studio version 12 (vs2013), 14 (vs2015), 15 (vs2017) etc. Default is 12.")
+                         help="Visual Studio version 12 (vs2013), 14 (vs2015), 15 (vs2017), 16 (vs2019). Default is 12.")
     p_build.add_argument('--vs-install-path',
                          help=r"The directory where you installed Visual Studio. Default is 'C:\Program Files (x86)\Microsoft Visual Studio $(vs-ver).0' (for vs-ver <= 14) " +
                          "or 'C:\Program Files (x86)\Microsoft Visual Studio\\20xx' (2017 for vs-ver 15, 2019 for vs-ver 16, ...). "


### PR DESCRIPTION
My goal was to build a Python wheel for GStreamer on Windows for Python 3.7 and Visual Studio 2019, and came across some minor documentation issues that I think might help other people. For other's that come across this I ran the following:

```
python build.py build -p x64 --vs-ver 16 --enable-gi --py-wheel gstreamer pygobject
```