### PR TITLE
add Project_gst_python

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -682,6 +682,20 @@ class Project_gst_plugins_bad(Tarball, Meson):
         Meson.build(self)
         self.install(r'.\COPYING share\doc\gst-plugins-bad')
 
+@project_add
+class Project_gst_python(Tarball, Meson):
+    def __init__(self):
+        Project.__init__(self,
+            'gst-python',
+            archive_url = 'https://gstreamer.freedesktop.org/src/gst-python/gst-python-1.16.2.tar.xz',
+            hash = '208df3148d73d9f416d016564737585d8ea763d91201732d44b5fe688c6288a8',
+            dependencies = ['meson', 'ninja', 'glib', 'gstreamer', 'pygobject'],
+            )
+
+    def build(self):
+        Meson.build(self)
+        self.install(r'.\COPYING share\doc\gst-python')
+
 class _MakeGir(object):
     """
     Class to build, with nmake, a single project .gir/.typelib files for the


### PR DESCRIPTION
Patterned after Project_gst_plugins_good
problem building because I need a pygobject.wrap file.

```
Found CMake: C:\gtk-build\tools\cmake-3.7.2-win64-x64\bin\cmake.EXE (3.7.2)
Run-time dependency pygobject-3.0 found: NO (tried pkgconfig and cmake)
Looking for a fallback subproject for the dependency pygobject-3.0

meson.build:23:0: ERROR: Subproject directory not found and pygobject.wrap file not found

A full log can be found at C:\gtk-build\build\x64\release\gst-python\_gvsbuild-meson\meson-logs\meson-log.txt
Traceback (most recent call last):
  File "D:\GitClones\gvsbuild-fork\gvsbuild\utils\builder.py", line 480, in build
    if self.__build_one(p):
  File "D:\GitClones\gvsbuild-fork\gvsbuild\utils\builder.py", line 606, in __build_one
    skip_deps = proj.build()
  File "D:\GitClones\gvsbuild-fork\gvsbuild\projects.py", line 696, in build
    Meson.build(self)
  File "D:\GitClones\gvsbuild-fork\gvsbuild\utils\base_builders.py", line 66, in build
    self.exec_vs(cmd, add_path=add_path)
  File "D:\GitClones\gvsbuild-fork\gvsbuild\utils\base_project.py", line 109, in exec_vs
    self.builder.exec_vs(cmd, working_dir=self._get_working_dir(), add_path=add_path)
  File "D:\GitClones\gvsbuild-fork\gvsbuild\utils\builder.py", line 845, in exec_vs
    self.__execute(self.__sub_vars(cmd), working_dir=working_dir, add_path=add_path, env=self.vs_env)
  File "D:\GitClones\gvsbuild-fork\gvsbuild\utils\builder.py", line 922, in __execute
    subprocess.check_call(args, cwd=working_dir, env=env, shell=True)
  File "C:\Users\Tim\AppData\Local\Programs\Python\Python37\lib\subprocess.py", line 363, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'C:\gtk-build\tools\python.3.7.7\tools\python.exe C:\gtk-build\tools\meson-0.52.0\meson.py C:\gtk-build\build\x64\release\gst-python C:\gtk-build\build\x64\release\gst-python\_gvsbuild-meson --prefix C:\gtk-build\gtk\x64\release --buildtype debugoptimized' returned non-zero exit status 1.
Error: gst-python build failed

```