### PR TITLE
fix wasapi patch

### DIFF
--- a/patches/gst-plugins-bad/0001-wasapi-added-missing-lock-release-in-case-of-error-i.patch
+++ b/patches/gst-plugins-bad/0001-wasapi-added-missing-lock-release-in-case-of-error-i.patch
@@ -18,11 +18,11 @@ index d21c42f90..0ecfb381b 100644
    GST_OBJECT_LOCK (self);
    hr = IAudioClient_Stop (self->client);
 -  HR_FAILED_AND (hr, IAudioClient::Stop,);
-+  HR_FAILED_AND (hr, IAudioClock::Stop, GST_OBJECT_UNLOCK (self); return);
++  HR_FAILED_AND (hr, IAudioClient::Stop, GST_OBJECT_UNLOCK (self); return);
  
    hr = IAudioClient_Reset (self->client);
 -  HR_FAILED_AND (hr, IAudioClient::Reset,);
-+  HR_FAILED_AND (hr, IAudioClock::Reset, GST_OBJECT_UNLOCK (self); return);
++  HR_FAILED_AND (hr, IAudioClient::Reset, GST_OBJECT_UNLOCK (self); return);
  
    self->client_needs_restart = TRUE;
    GST_OBJECT_UNLOCK (self);


### PR DESCRIPTION
The current version of wasapi included in gst-plugins-bad has a bug that in some cases leads to a deadlock