### PR TITLE
Add framework for application projects

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,6 +1,7 @@
 #  Copyright (C) 2016 - Yevgen Muntyan
 #  Copyright (C) 2016 - Ignacio Casal Quinteiro
 #  Copyright (C) 2016 - Arnavion
+#  Copyright (C) 2020 - Daniel F. Dickinson
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -40,6 +41,8 @@ import gvsbuild.tools
 import gvsbuild.projects
 # ... and groups
 import gvsbuild.groups
+# ... and applications
+import gvsbuild.applications
 
 if __name__ == '__main__':
     parser = create_parser()

--- a/gvsbuild/applications.py
+++ b/gvsbuild/applications.py
@@ -1,0 +1,59 @@
+#  Copyright (C) 2016 - Yevgen Muntyan
+#  Copyright (C) 2016 - Ignacio Casal Quinteiro
+#  Copyright (C) 2016 - Arnavion
+#  Copyright (C) 2020 - Daniel F. Dickinson
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""
+Default apps to build
+"""
+
+import os
+import glob
+import shutil
+
+from .utils.simple_ui import log
+from .utils.utils import convert_to_msys
+from .utils.utils import file_replace
+from .utils.utils import python_find_libs_dir
+from .utils.base_expanders import Tarball, GitRepo
+from .utils.base_expanders import NullExpander
+from .utils.base_application import Application, application_add
+from .utils.base_project import Project
+from .utils.base_project import GVSBUILD_IGNORE
+from .utils.base_builders import Meson, MercurialCmakeProject, CmakeProject, Rust
+
+
+@application_add
+class Application_zim_desktop_wiki(GitRepo, Project):
+    def __init__(self):
+        GitRepo.__init__(self)
+        Application.__init__(self,
+            'zim-desktop-wiki',
+            repo_url = 'https://github.com/zim-desktop-wiki/zim-desktop-wiki',
+            fetch_submodules = False,
+            tag = '0.73.2',
+            dependencies = [
+                'adwaita-icon-theme',
+                'python',
+                'gtksourceview3',
+                'gtk3',
+                'hicolor-icon-theme',
+                'pygobject'
+            ],
+            enable_gi = True, )
+
+    def build(self):
+        pass

--- a/gvsbuild/groups.py
+++ b/gvsbuild/groups.py
@@ -2,6 +2,7 @@
 #  Copyright (C) 2016 - Ignacio Casal Quinteiro
 #  Copyright (C) 2016 - Arnavion
 #  Copyright (C) 2017 - Daniele Forghieri
+#  Copyright (C) 2020 - Daniel F. Dickinson
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -21,7 +22,7 @@ Default groups of projects
 """
 
 from .utils.base_group import Group, group_add
-from .utils.base_project import Project, GVSBUILD_PROJECT
+from .utils.base_project import Project, GVSBUILD_PROJECT, GVSBUILD_APPLICATION
 
 @group_add
 class Group_Tools(Group):
@@ -77,9 +78,27 @@ class Group_Tools_Check(Group):
             )
 
 @group_add
-class Group_All(Group):
+class Group_All_Libraries(Group):
     def __init__(self):
         all_prj = [x.name for x in Project._projects if x.type == GVSBUILD_PROJECT]
+        Group.__init__(self,
+            'all-libraries',
+            dependencies = all_prj
+        )
+
+@group_add
+class Group_All_Applications(Group):
+    def __init__(self):
+        all_prj = [x.name for x in Project._projects if x.type == GVSBUILD_APPLICATION]
+        Group.__init__(self,
+            'all-applications',
+            dependencies = all_prj
+        )
+
+@group_add
+class Group_All(Group):
+    def __init__(self):
+        all_prj = [x.name for x in Project._projects if (x.type == GVSBUILD_PROJECT or x.type == GVSBUILD_APPLICATION)]
         Group.__init__(self,
             'all',
             dependencies = all_prj

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -47,7 +47,7 @@ class Project_adwaita_icon_theme(Tarball, Project):
     def build(self):
         # Create the destination dir, before the build
         os.makedirs(os.path.join(self.builder.gtk_dir, 'share', 'icons', 'Adwaita'), exist_ok=True)
-        
+
         self.push_location(r'.\win32')
         self.exec_vs(r'nmake /nologo /f adwaita-msvc.mak CFG=%(configuration)s PYTHON="%(python_dir)s\python.exe" PREFIX="%(gtk_dir)s"', add_path=os.path.join(self.builder.opts.msys_dir, 'usr', 'bin'))
         self.exec_vs(r'nmake /nologo /f adwaita-msvc.mak install CFG=%(configuration)s PYTHON="%(python_dir)s\python.exe" PREFIX="%(gtk_dir)s"', add_path=os.path.join(self.builder.opts.msys_dir, 'usr', 'bin'))
@@ -954,7 +954,7 @@ class Project_icu(Tarball, Project):
             bindir += '64'
             libdir += '64'
         if self.opts.vs_ver != '15':
-            # Not Vs2017, we change the platform 
+            # Not Vs2017, we change the platform
             search, replace = self._msbuild_make_search_replace(141)
             self._msbuild_copy_dir(None, os.path.join(self.build_dir, 'source', 'allinone'), search, replace)
 
@@ -1402,8 +1402,8 @@ class Project_libuv(Tarball, CmakeProject):
             archive_url = 'https://github.com/libuv/libuv/archive/v1.35.0.tar.gz',
             hash = 'ff84a26c79559e511f087aa67925c3b4e0f0aac60cd8039d4d38b292f208ff58',
             dependencies = [
-                'cmake', 
-                'ninja',  
+                'cmake',
+                'ninja',
                 ],
             )
 
@@ -1982,6 +1982,33 @@ class Project_x264(GitRepo, Project):
         self.builder.exec_msys(['mv', 'libx264.dll.lib', 'libx264.lib'], working_dir=os.path.join(self.builder.gtk_dir, 'lib'))
 
         self.install(r'.\COPYING share\doc\x264')
+
+@project_add
+class Project_xdg(GitRepo, Project):
+    def __init__(self):
+        GitRepo.__init__(self)
+        Project.__init__(self,
+            'xdg',
+            repo_url = 'https://github.com/srstevenson/xdg.git',
+            fetch_submodules = False,
+            tag = '4.0.1',
+            dependencies = ['python', 'poetry']
+        )
+
+    def build(self):
+        self.push_location(self.build_dir)
+        python = Project.get_tool_executable('python')
+        poetry = Project.get_tool_executable('poetry')
+        self.exec_cmd('%s %s build' % (python, poetry), working_dir=self.build_dir)
+        self.exec_cmd('%s -m pip install %s' % (python, 'dist/xdg-4.0.1-py3-none-any.whl'), working_dir=self.build_dir)
+        if self.builder.opts.py_egg:
+            self.exec_vs(r'%(python_dir)s\python.exe setup.py bdist_egg')
+        if self.builder.opts.py_wheel:
+            self.exec_vs(r'%(python_dir)s\python.exe setup.py bdist_wheel')
+        if self.builder.opts.py_egg or self.builder.opts.py_wheel:
+            self.install_dir('dist', 'python')
+        self.install(r'.\LICENCE .\README.md share\doc\xdg')
+        self.pop_location()
 
 @project_add
 class Project_zlib(Tarball, Project):

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -233,6 +233,28 @@ class Tool_poetry(Tool):
         self.mark_deps = True
 
 @tool_add
+class Tool_pyinstaller(Tool):
+    def __init__(self):
+        Tool.__init__(self,
+            'pyinstaller',
+            dependencies = [ 'python' ],
+            )
+
+    def load_defaults(self):
+        Tool.load_defaults(self)
+        python_dir = Tool.get_tool_path('python')
+        self.tool_path = os.path.join(python_dir, 'tools', 'Scripts')
+
+    def unpack(self):
+        # python
+        python_exe = Tool.get_tool_executable('python')
+
+        # Install pyinstaller
+        cmd = python_exe + ' -m pip install pyinstaller'
+        subprocess.check_call(cmd, shell=True)
+        self.tool_mark()
+
+@tool_add
 class Tool_python(Tool):
     def __init__(self):
         Tool.__init__(self,

--- a/gvsbuild/utils/base_application.py
+++ b/gvsbuild/utils/base_application.py
@@ -1,0 +1,52 @@
+#  Copyright (C) 2016 - Yevgen Muntyan
+#  Copyright (C) 2016 - Ignacio Casal Quinteiro
+#  Copyright (C) 2016 - Arnavion
+#  Copyright (C) 2020 - Daniel F. Dickinson
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""
+Base application class, from the project one
+"""
+
+import os
+
+from .base_project import Project, GVSBUILD_APPLICATION
+
+class Application(Project):
+    def __init__(self, name, **kwargs):
+        self.dir_part = None
+        self.mark_deps = False
+        self.application_path = None
+        Project.__init__(self, name, **kwargs)
+
+    # def build(self):
+        # FIXME: Need to add build machinery for various types of application
+        # pass
+
+    def update_build_dir(self):
+        self.unpack()
+
+    def get_path(self):
+        if self.application_path:
+            return self.application_path
+        else:
+            return self.build_dir
+
+def application_add(cls):
+    """
+    Class decorator to add the newly created Toolp class to the global projects/tools/groups list
+    """
+    Project.register(cls, GVSBUILD_APPLICATION)
+    return cls

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -48,7 +48,7 @@ class Project(object):
     def __init__(self, name, **kwargs):
         object.__init__(self)
         self.name = name
-        self.prj_dir = name 
+        self.prj_dir = name
         self.dependencies = []
         self.patches = []
         self.archive_url = None
@@ -60,6 +60,7 @@ class Project(object):
         self.clean = False
         self.to_add = True
         self.extra_env = {}
+        self.enable_gi = False
         for k in kwargs:
             setattr(self, k, kwargs[k])
         self.__working_dir = None
@@ -75,7 +76,7 @@ class Project(object):
     name_len = 0
     # List of class/type to add, now not at import time but after some options are parsed
     _reg_prj_list = []
-    # build option 
+    # build option
     opts = Options()
 
     def __str__(self):
@@ -87,7 +88,7 @@ class Project(object):
     def load_defaults(self):
         # Used by the tools to load default paths/filenames
         pass
-    
+
     def finalize_dep(self, builder, deps):
         """
         Used to manipulate the dependencies list, to add or remove projects
@@ -103,7 +104,7 @@ class Project(object):
 
     def add_dependency(self, dep):
         self.dependencies.append(dep)
-        
+
     def exec_cmd(self, cmd, working_dir=None, add_path=None):
         self.builder.exec_cmd(cmd, working_dir=working_dir, add_path=add_path)
 
@@ -120,7 +121,7 @@ class Project(object):
         Return the search & replace strings (converted to bytes to update the
         platfomrm Toolset version (v140, v141, ...) to use a new compiler,
         e.g. to use vs2017 solution's files for vs2019
-        
+
         The '<PlatformToolset' at the beginning is missing to handle projects
         like libmictohttpd that has a condition in the platform definition
         """
@@ -177,7 +178,7 @@ class Project(object):
     def exec_msbuild_gen(self, base_dir, sln_file, add_pars='', configuration=None, add_path=None, use_env=False):
         '''
         looks for base_dir\{vs_ver}\sln_file or base_dir\{vs_ver_tear}\sln_file for launching the msbuild commamd.
-        If it's not present in the directory the system start to look backward to find the first version present 
+        If it's not present in the directory the system start to look backward to find the first version present
         '''
         def _msbuild_ok(self, dir_part):
             full = os.path.join(self.build_dir, base_dir, dir_part, sln_file)
@@ -244,7 +245,7 @@ class Project(object):
 
     def install_pc_files(self, base_dir='pc-files'):
         '''
-        Install, setting dir & version, the .pc files 
+        Install, setting dir & version, the .pc files
         '''
         pkgconfig_dir = os.path.join(self.builder.gtk_dir, 'lib', 'pkgconfig')
         self.builder.make_dir(pkgconfig_dir)
@@ -342,11 +343,11 @@ class Project(object):
         Register the class to be added after some initialization
         """
         Project._reg_prj_list.append((cls, ty, ))
-        
+
     @staticmethod
     def add_all():
         """
-        Add all the registered class 
+        Add all the registered class
         """
         for cls, ty in Project._reg_prj_list:
             c_inst = cls()
@@ -361,7 +362,7 @@ class Project(object):
         Mark the project not to build/add to the list
         """
         self.to_add = False
-         
+
     @staticmethod
     def get_project(name):
         return Project._dict[name]
@@ -396,7 +397,7 @@ class Project(object):
     def get_tool_executable(tool):
         if not isinstance(tool, Project):
             tool = Project._dict[tool]
-            
+
         if tool.type == GVSBUILD_TOOL:
             return tool.get_executable()
         return None
@@ -405,7 +406,7 @@ class Project(object):
     def get_tool_base_dir(tool):
         if not isinstance(tool, Project):
             tool = Project._dict[tool]
-            
+
         if tool.type == GVSBUILD_TOOL:
             return tool.get_base_dir()
         return None
@@ -428,7 +429,7 @@ class Project(object):
                 re.compile('.*-([0-9a-f]+)\.'),
                 re.compile('.*([0-9]\.[0-9]+)\.'),
                 ]
-        
+
         ver = ''
         for r in Project._ver_res:
             ok = r.match(file_name)
@@ -437,7 +438,7 @@ class Project(object):
                 break
         log.debug('Version from file name:%-16s <- %s' % (ver, file_name, ))
         return ver
-            
+
     def _calc_version(self):
         if self.archive_file_name:
             self.version = Project._file_to_version(self.archive_file_name)
@@ -446,21 +447,21 @@ class Project(object):
             self.version = Project._file_to_version(name)
         else:
             if hasattr(self, 'tag') and self.tag:
-                self.version = 'git/' + self.tag 
+                self.version = 'git/' + self.tag
             elif hasattr(self, 'repo_url'):
                 self.version = 'git/master'
             else:
                 self.version = ''
-    
+
     def mark_file_calc(self):
         if not self.mark_file:
             self.mark_file = os.path.join(self.build_dir, '.wingtk-built')
-            
+
     def mark_file_remove(self):
         self.mark_file_calc()
         if os.path.isfile(self.mark_file):
             os.remove(self.mark_file)
-            
+
     def mark_file_write(self):
         self.mark_file_calc()
         try:
@@ -469,7 +470,7 @@ class Project(object):
                 fo.write('%s\n' % (now.strftime('%Y-%m-%d %H:%M:%S'), ))
         except FileNotFoundError as e:
             log.debug("Exception writing file '%s' (%s)" % (self.mark_file, e, ))
-        
+
     def mark_file_exist(self):
         rt = None
         self.mark_file_calc()

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -43,6 +43,7 @@ class Options(object):
         self.ffmpeg_enable_gpl = False
         # Default
         self._load_python = False
+        self.old_rsvg = False
 
 class Project(object):
     def __init__(self, name, **kwargs):

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -1,6 +1,7 @@
 #  Copyright (C) 2016 - Yevgen Muntyan
 #  Copyright (C) 2016 - Ignacio Casal Quinteiro
 #  Copyright (C) 2016 - Arnavion
+#  Copyright (C) 2020 - Daniel F. Dickinson
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -32,6 +33,7 @@ GVSBUILD_IGNORE = 0
 GVSBUILD_PROJECT = 1
 GVSBUILD_TOOL = 2
 GVSBUILD_GROUP = 3
+GVSBUILD_APPLICATION = 4
 
 class Options(object):
     def __init__(self):
@@ -483,9 +485,12 @@ class Project(object):
     def is_project(self):
         return self.type == GVSBUILD_PROJECT
 
+    def is_application(self):
+        return self.type == GVSBUILD_APPLICATION
+
 def project_add(cls):
     """
-    Class decorator to add the newly created Project class to the global projects/tools/groups list
+    Class decorator to add the newly created Project class to the global projects/tools/groups/applications list
     """
     Project.register(cls, GVSBUILD_PROJECT)
     return cls

--- a/gvsbuild/utils/base_tool.py
+++ b/gvsbuild/utils/base_tool.py
@@ -53,6 +53,7 @@ class Tool(Project):
         self.unpack()
 
     def get_path(self):
+        self.load_defaults()
         if self.tool_path:
             return self.tool_path
         else:

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -90,7 +90,7 @@ def get_options(args):
     prop_file = os.path.join(opts.patches_root_dir, 'stack.props')
     if not os.path.isfile(prop_file):
         log.error_exit("Missing 'stack.prop' file on directory '%s'.\nWrong or missing --patches-root-dir option?" % (opts.patches_root_dir, ))
-        
+
     opts._vs_path_auto = False
     if not opts.tools_root_dir:
         opts.tools_root_dir = os.path.join(args.build_dir, 'tools')
@@ -117,6 +117,10 @@ def get_options(args):
             log.error_exit(
                 p + " is not a valid project name, available projects are:\n\t" + "\n\t".join(Project.get_names()))
 
+        proj = Project.get_project(p)
+        if proj.enable_gi != False:
+            if opts.enable_gi != True:
+                raise ValueError("%s requires --enable-gi" % proj.name)
     return opts
 
 def __get_projects_to_build(opts):
@@ -124,7 +128,7 @@ def __get_projects_to_build(opts):
     if opts._load_python:
         # We use nuget to download & install the python needed for the build so we put it at the beginning
         opts.projects.insert(0, 'python')
-        
+
     for name in opts.projects:
         p = Project.get_project(name)
         if not opts.no_deps:
@@ -157,7 +161,7 @@ def do_build(args):
             if type(v) is str:
                 pv = "'%s'" % (v, )
             else:
-                pv = repr(v) 
+                pv = repr(v)
             log.message_indent("'%s': %s, " % (co, pv, ))
     builder = Builder(opts)
     builder.preprocess()
@@ -174,7 +178,7 @@ def do_list(args):
         nl = [ (x.name, x.version, ) for x in Project._projects if x.type == prj_type]
         if nl:
             nl.sort()
-            
+
             print("%s:" % (desc, ))
             for i in nl:
                 print('\t%-*s %s' % (Project.name_len, i[0], i[1], ))

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -1,6 +1,7 @@
 #  Copyright (C) 2016 - Yevgen Muntyan
 #  Copyright (C) 2016 - Ignacio Casal Quinteiro
 #  Copyright (C) 2016 - Arnavion
+#  Copyright (C) 2020 - Daniel F. Dickinson
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -23,7 +24,7 @@ import argparse
 import os
 import sys
 
-from .base_project import Project, GVSBUILD_PROJECT, GVSBUILD_TOOL, GVSBUILD_GROUP, GVSBUILD_IGNORE
+from .base_project import Project, GVSBUILD_PROJECT, GVSBUILD_TOOL, GVSBUILD_APPLICATION, GVSBUILD_GROUP, GVSBUILD_IGNORE
 from .base_project import Options
 from .builder import Builder
 from .utils import ordered_set
@@ -108,7 +109,7 @@ def get_options(args):
 
     opts.projects = args.project
     Project.opts = opts
-    # now add the tools/projects/groups
+    # now add the tools/projects/groups/applications
     Project.add_all()
 
     for p in opts.projects:
@@ -182,6 +183,7 @@ def do_list(args):
     Project.add_all()
     do_list_type(GVSBUILD_TOOL, "Available tools")
     do_list_type(GVSBUILD_PROJECT, "Available projects")
+    do_list_type(GVSBUILD_APPLICATION, "Available applications")
     do_list_type(GVSBUILD_GROUP, "Available groups")
     do_list_type(GVSBUILD_IGNORE, "Developer project(s)")
     sys.exit(0)


### PR DESCRIPTION
* Add a framework for an 'application' (type of project).  This is intended to allow adding application tooling such as building installers and bundling the application and dependencies for distribution.
* Some applications require gtk3 to have gi enabled.  Allow those applicatoins to fail the build if --enable-gi is missing.
* A couple of fixes for deps.py (I can split these out if necessary).