### PR TITLE
Fix fribidi has no attribute repo_url

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -410,7 +410,7 @@ class Project_freerdp(Tarball, CmakeProject):
         self.install(r'.\LICENSE share\doc\freerdp')
 
 @project_add
-class Project_fribidi(GitRepo, Meson):
+class Project_fribidi(Tarball, Meson):
     def __init__(self):
         Project.__init__(self,
             'fribidi',


### PR DESCRIPTION
Commit c21950b changed from using git for fribidi to using the release tarball, but the class inheritance wasn't updated.