### PR TITLE
Update Python versions to support Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ HexChat developers decided that their script should focus on their specific need
 
     * [Visual Studio for Windows Desktop](http://www.visualstudio.com/downloads) - 2013 (not for all projects), 2015, 2017 and 2019 are currently supported.
     * [msys2](https://msys2.github.io/)
-    * [Python 3.6](https://www.python.org/ftp/python/3.6.2/python-3.6.2-amd64.exe) (install in C:\Python36 or use the --python-dir option to tell the script the correct location), or other package like [Miniconda 3](https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe)
+    * [Latest Python 3](https://www.python.org/downloads/windows/) (install in C:\Python3x, for example C:\Python310, or use the --python-dir option to tell the script the correct location), or other package like [Miniconda 3](https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe)
 
 1. Follow the instructions on the msys2 page to update the core packages. The needed packages for the script (make, diffutils, ...) are download and installed automatically if not presents in the msys2 installation.
 

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -195,16 +195,14 @@ class Tool_python(Tool):
         """
         version = self.opts.python_ver;
         # Get the last version we ask
-        if version == '3.5':
-            version = '3.5.4'
-        elif version == '3.6':
-            version = '3.6.8'
-        elif version == '3.7':
-            version = '3.7.9'
+        if version == '3.7':
+            version = '3.7.12'
         elif version == '3.8':
-            version = '3.8.8'
+            version = '3.8.12'
         elif version == '3.9':
-            version = '3.9.2'
+            version = '3.9.7'
+        elif version == '3.10':
+            version = '3.10.0'
 
         if self.opts.x86:
             name = 'pythonx86'

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -257,8 +257,8 @@ Examples:
                                "16299, 17134 or 17763 " +
                                "depending on the VS version / installation's options. " +
                                "If you don't specify one the scripts tries to locate the used one to pass the value to the msbuild command.")
-    p_build.add_argument('--python-ver', default='3.9',
-                         help='Python version to download and use for the build (3.7, 3.6, 3.5 or the exact one, 3.5.2.1 or 3.8.0-a3.')
+    p_build.add_argument('--python-ver', default='3.10',
+                         help='Python version to download and use for the build (3.10, 3.9, 3.8, 3.7, or the exact one, 3.5.2.1 or 3.8.0-a3.')
     p_build.add_argument('--python-dir', default=None,
                          help="The directory containing the python you want to use for the build of the projects (not the one used to run the script).")
     p_build.add_argument('--same-python', default=False, action='store_true',


### PR DESCRIPTION
This PR drops support for Python 3.5 and 3.6, and adds support for Python 3.10. It also updates the minor versions for the others.