### PR TITLE
Fix image and link to CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gvsbuild
 
-![CI](https://github.com/wingtk/gvsbuild/workflows/ci/badge.svg)
+[![CI](https://github.com/wingtk/gvsbuild/actions/workflows/ci.yml/badge.svg)](https://github.com/wingtk/gvsbuild/actions/workflows/ci.yml)
 
 This python script helps you build a full [GTK](https://www.gtk.org/) library stack for Windows using Visual Studio.
 


### PR DESCRIPTION
The current README shows a link instead of the CI badge.