### PR TITLE
Enable Additional Pre-commit Hooks and Fix Errors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, E501
+show-source = True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,11 @@ repos:
   hooks:
   - id: isort
     additional_dependencies: [toml]
+- repo: https://github.com/myint/docformatter
+  rev: v1.4
+  hooks:
+    - id: docformatter
+      args: [--in-place]
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.29.1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,11 @@ repos:
   hooks:
   - id: black
     language_version: python3
+- repo: https://github.com/PyCQA/flake8
+  rev: 4.0.1
+  hooks:
+    - id: flake8
+      additional_dependencies: [flake8-eradicate==1.2.0]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.0.1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,8 @@ repos:
   rev: v2.29.1
   hooks:
   - id: pyupgrade
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.8.0.3
+  hooks:
+    - id: shellcheck
+      args: [--exclude, SC1017]

--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@
 
 # Verify we can import from the script directory
 try:
-    import gvsbuild.utils.utils
+    import gvsbuild.utils.utils  # noqa: F401
 except ImportError:
     # We are probably using an embedded installation
     print("Error importing utility, fixing paths ...")
@@ -31,9 +31,9 @@ except ImportError:
     # and add it at the beginning, emulating the standard python startup
     sys.path.insert(0, script_dir)
 
-import gvsbuild.groups
-import gvsbuild.projects
-import gvsbuild.tools
+import gvsbuild.groups  # noqa: F401
+import gvsbuild.projects  # noqa: F401
+import gvsbuild.tools  # noqa: F401
 from gvsbuild.utils.parser import create_parser
 
 if __name__ == "__main__":

--- a/deps.py
+++ b/deps.py
@@ -33,9 +33,9 @@ except ImportError:
 
 import argparse
 
-import gvsbuild.groups
-import gvsbuild.projects
-import gvsbuild.tools
+import gvsbuild.groups  # noqa: F401
+import gvsbuild.projects  # noqa: F401
+import gvsbuild.tools  # noqa: F401
 from gvsbuild.utils.base_project import (
     GVSBUILD_GROUP,
     GVSBUILD_PROJECT,

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -2052,7 +2052,7 @@ class Project_openssl(Tarball, Project):
 
         try:
             self.exec_vs(r"nmake /nologo clean", add_path=add_path)
-        except:
+        except:  # noqa E722
             pass
 
         self.exec_vs(r"nmake /nologo", add_path=add_path)

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -2056,7 +2056,6 @@ class Project_openssl(Tarball, Project):
             pass
 
         self.exec_vs(r"nmake /nologo", add_path=add_path)
-        # self.exec_vs(r'nmake /nologo test', add_path=add_path)
         self.exec_vs(r"%(perl_dir)s\bin\perl.exe mk-ca-bundle.pl -n cert.pem")
         self.exec_vs(r"nmake /nologo install", add_path=add_path)
 

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -19,9 +19,8 @@
 
 import glob
 import os
-import shutil
 
-from .utils.base_builders import CmakeProject, MercurialCmakeProject, Meson, Rust
+from .utils.base_builders import CmakeProject, Meson, Rust
 from .utils.base_expanders import GitRepo, NullExpander, Tarball
 from .utils.base_project import GVSBUILD_IGNORE, Project, project_add
 from .utils.simple_ui import log

--- a/gvsbuild/utils/base_builders.py
+++ b/gvsbuild/utils/base_builders.py
@@ -20,7 +20,7 @@
 import os
 import shutil
 
-from .base_expanders import MercurialRepo, Tarball
+from .base_expanders import MercurialRepo
 from .base_project import Project
 from .simple_ui import log
 from .utils import _rmtree_error_handler

--- a/gvsbuild/utils/base_expanders.py
+++ b/gvsbuild/utils/base_expanders.py
@@ -28,7 +28,7 @@ from .utils import rmtree_full
 
 
 def read_mark_file(directory, file_name=".wingtk-extracted-file"):
-    """ " Read a single line from file, returning an empty string on error."""
+    """Read a single line from file, returning an empty string on error."""
     rt = ""
     try:
         with open(os.path.join(directory, file_name), "rt") as fi:
@@ -209,7 +209,7 @@ def dirlist2set(st_dir, add_dirs=False, skipped_dir=None):
 
 
 def make_zip_hash(files):
-    """ " Calculate an hash of all the files to put in a zip file."""
+    """Calculate an hash of all the files to put in a zip file."""
     hash_calc = hashlib.sha256()
     for file_name in sorted(list(files)):
         # add also the file full path, to support only moving files in the zip

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -806,7 +806,6 @@ class Builder(object):
             self.__copy_to(f, destdir)
 
     def __copy_to(self, src, destdir):
-        # log.debug("__copy_to %s %s" % (src, destdir))
         self.make_dir(destdir)
         for f in glob.glob(src):
             if os.path.isdir(f):

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -448,19 +448,19 @@ class Builder(object):
 
         self.vs_env = {}
         dbg = log.debug_on()
-        for l in output.splitlines():
+        for line in output.splitlines():
             # Python3 str is not bytes and no need to decode
-            if isinstance(l, bytes):
+            if isinstance(line, bytes):
                 try:
-                    tl = l.decode("utf-8")
+                    decoded_line = line.decode("utf-8")
                 except UnicodeDecodeError:
-                    log.message("Warning: utf-8 decode error on [{}]".format(l))
-                    tl = l.decode("utf-8", errors="replace")
-                l = tl
+                    log.message("Warning: utf-8 decode error on [{}]".format(line))
+                    decoded_line = line.decode("utf-8", errors="replace")
+                line = decoded_line
 
-            e = l.split("=", 1)
+            e = line.split("=", 1)
             if len(e) < 2:
-                log.debug("vs env: ignoring %s" % (l))
+                log.debug("vs env: ignoring %s" % (line))
                 continue
             k, v = e
             # Be sure to have PATH in upper case because we need to manipulate it

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -598,7 +598,7 @@ class Builder(object):
             except KeyboardInterrupt:
                 traceback.print_exc()
                 log.error_exit("Interrupted on {}".format(p.name))
-            except:
+            except:  # noqa E722
                 traceback.print_exc()
                 log.end(mark_error=True)
                 if self.opts.keep:

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -131,7 +131,7 @@ def get_options(args):
     Project.add_all()
 
     for p in opts.projects:
-        if not p in Project.get_names():
+        if p not in Project.get_names():
             log.error_exit(
                 p
                 + " is not a valid project name, available projects are:\n\t"
@@ -160,7 +160,7 @@ def __get_projects_to_build(opts):
     if opts.skip:
         to_skip = opts.skip.split(",")
         for s in to_skip:
-            if not s in Project.get_names():
+            if s not in Project.get_names():
                 log.error_exit(
                     s
                     + " is not a valid project name, available projects are:\n\t"

--- a/gvsbuild/utils/simple_ui.py
+++ b/gvsbuild/utils/simple_ui.py
@@ -274,15 +274,15 @@ class Log(object):
             prt = True
 
         lines = msgs.split("\n")
-        lines = [l.rstrip() for l in lines if l.rstrip() != ""]
+        lines = [line.rstrip() for line in lines if line.rstrip() != ""]
         if self.fo:
             # On the file, if active
-            for l in lines:
-                self.fo.write("    {}\n".format(l))
+            for line in lines:
+                self.fo.write("    {}\n".format(line))
 
         if prt:
-            for l in lines:
-                print(l)
+            for line in lines:
+                print(line)
 
     def log(self, msg):
         if self._verbose:
@@ -335,7 +335,7 @@ if __name__ == "__main__":
     log.start("Test #2, nested")
     time.sleep(0.5)
     log.end()
-    with log.simple_oper("Test with context manager") as l:
+    with log.simple_oper("Test with context manager"):
         time.sleep(0.35)
         with log.simple_oper("Second test with context manager"):
             time.sleep(0.15)

--- a/gvsbuild/utils/simple_ui.py
+++ b/gvsbuild/utils/simple_ui.py
@@ -64,7 +64,7 @@ class LogElem(object):
 
 
 class Log(object):
-    """ " Simple log class, used mainly to time the execution of the script."""
+    """Simple log class, used mainly to time the execution of the script."""
 
     _verbose = False
     _debug = False

--- a/gvsbuild/utils/utils.py
+++ b/gvsbuild/utils/utils.py
@@ -98,7 +98,7 @@ class ordered_set(set):
         self.__list = list()
 
     def add(self, o):
-        if not o in self:
+        if o not in self:
             set.add(self, o)
             self.__list.append(o)
 

--- a/gvsbuild/utils/utils.py
+++ b/gvsbuild/utils/utils.py
@@ -48,7 +48,7 @@ def rmtree_full(dest_dir, retry=False):
             try:
                 shutil.rmtree(dest_dir, onerror=_rmtree_error_handler)
                 break
-            except:
+            except:  # noqa: E722
                 # wait a little, don't ask me why ;(
                 time.sleep(delay)
     else:

--- a/patches/ffmpeg/build/build.sh
+++ b/patches/ffmpeg/build/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bash
+
 prefix="$1"
 gtk_dir="$2"
 build_type="$3"
@@ -19,34 +21,34 @@ fi
 export PKG_CONFIG_PATH=$gtk_dir/lib/pkgconfig:$PKG_CONFIG_PATH
 
 ./configure \
-    --toolchain=msvc \
-    --prefix="$prefix" \
-    --enable-shared \
-    --disable-everything \
-    --enable-swscale \
-    --enable-avcodec \
-    --enable-hwaccel=h264_dxva2 \
-    --enable-hwaccel=hevc_dxva2 \
-    --enable-dxva2 \
-    --enable-decoder=h264 \
-    --enable-decoder=hevc \
-    --enable-decoder=mpeg1video \
-    --enable-encoder=mpeg1video \
-    --enable-hwaccel=h264_d3d11va \
-    --enable-hwaccel=h264_d3d11va2 \
-    --enable-hwaccel=hevc_d3d11va \
-    --enable-hwaccel=hevc_d3d11va2 \
-    --enable-d3d11va \
-    --enable-nvdec \
-    --enable-hwaccel=h264_nvdec \
-    --enable-hwaccel=hevc_nvdec \
-    --disable-programs \
-    --disable-avformat \
-    --disable-avfilter \
-    --disable-avdevice \
-    --disable-swresample \
-    --extra-cflags="$extra_cflags" \
-    $extra_flags
+ --toolchain=msvc \
+ --prefix="$prefix" \
+ --enable-shared \
+ --disable-everything \
+ --enable-swscale \
+ --enable-avcodec \
+ --enable-hwaccel=h264_dxva2 \
+ --enable-hwaccel=hevc_dxva2 \
+ --enable-dxva2 \
+ --enable-decoder=h264 \
+ --enable-decoder=hevc \
+ --enable-decoder=mpeg1video \
+ --enable-encoder=mpeg1video \
+ --enable-hwaccel=h264_d3d11va \
+ --enable-hwaccel=h264_d3d11va2 \
+ --enable-hwaccel=hevc_d3d11va \
+ --enable-hwaccel=hevc_d3d11va2 \
+ --enable-d3d11va \
+ --enable-nvdec \
+ --enable-hwaccel=h264_nvdec \
+ --enable-hwaccel=hevc_nvdec \
+ --disable-programs \
+ --disable-avformat \
+ --disable-avfilter \
+ --disable-avdevice \
+ --disable-swresample \
+ --extra-cflags="$extra_cflags" \
+ "$extra_flags"
 
 make
 make install

--- a/patches/x264/build/build.sh
+++ b/patches/x264/build/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 prefix=$1
 build_type=$2
 
@@ -9,5 +11,5 @@ if [ "$build_type" = "debug" ]; then
     extra_cflags="-MDd -Od -Zi $extra_cflags"
 fi
 
-CC=cl ./configure --enable-shared --prefix="$prefix" $extra_flags --extra-cflags="$extra_cflags"
+CC=cl ./configure --enable-shared --prefix="$prefix" "$extra_flags" --extra-cflags="$extra_cflags"
 make install


### PR DESCRIPTION
This PR enables the following pre-commit hooks:

- flake8
- docformatter
- shellcheck

It also fixes errors found by as part of enabling the new checks. These will be run automatically along with Black in the lint phase of the CI build.