### PR TITLE
fix gtk 3.20, 3.22 build failure on windows

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -942,9 +942,10 @@ class Project_gtk3_20(Project_gtk_base):
             self.add_dependency("gobject-introspection")
 
     def build(self):
-        self.exec_msbuild_gen(
-            r"build\win32", "gtk+.sln", add_pars="/p:GtkPostInstall=rem"
+        self.builder.mod_env(
+            "INCLUDE", "{}\\include\\harfbuzz".format(self.builder.gtk_dir)
         )
+        self.exec_msbuild_gen(r"build\win32", "gtk+.sln", add_pars="/p:UseEnv=True /p:GtkPostInstall=rem")
 
         self.make_all_mo()
 
@@ -982,9 +983,10 @@ class Project_gtk3_22(Project_gtk_base):
             self.add_dependency("gobject-introspection")
 
     def build(self):
-        self.exec_msbuild_gen(
-            r"build\win32", "gtk+.sln", add_pars="/p:GtkPostInstall=rem"
+        self.builder.mod_env(
+            "INCLUDE", "{}\\include\\harfbuzz".format(self.builder.gtk_dir)
         )
+        self.exec_msbuild_gen(r"build\win32", "gtk+.sln", add_pars="/p:UseEnv=True /p:GtkPostInstall=rem")
 
         self.make_all_mo()
 

--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -945,7 +945,9 @@ class Project_gtk3_20(Project_gtk_base):
         self.builder.mod_env(
             "INCLUDE", "{}\\include\\harfbuzz".format(self.builder.gtk_dir)
         )
-        self.exec_msbuild_gen(r"build\win32", "gtk+.sln", add_pars="/p:UseEnv=True /p:GtkPostInstall=rem")
+        self.exec_msbuild_gen(
+            r"build\win32", "gtk+.sln", add_pars="/p:UseEnv=True /p:GtkPostInstall=rem"
+        )
 
         self.make_all_mo()
 
@@ -986,7 +988,9 @@ class Project_gtk3_22(Project_gtk_base):
         self.builder.mod_env(
             "INCLUDE", "{}\\include\\harfbuzz".format(self.builder.gtk_dir)
         )
-        self.exec_msbuild_gen(r"build\win32", "gtk+.sln", add_pars="/p:UseEnv=True /p:GtkPostInstall=rem")
+        self.exec_msbuild_gen(
+            r"build\win32", "gtk+.sln", add_pars="/p:UseEnv=True /p:GtkPostInstall=rem"
+        )
 
         self.make_all_mo()
 


### PR DESCRIPTION
When building gtk 3.20, 3.22 on windows, I got `fatal error C1083: Cannot open include file: 'hb.h': No such file or directory`, see https://github.com/wingtk/gvsbuild/issues/474 for more details.