### PR TITLE
gst-plugins-bad: add patch for wasapisink latency reduction

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -801,7 +801,10 @@ class Project_gst_plugins_bad(Tarball, Meson):
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.18.4.tar.xz",
             hash="74e806bc5595b18c70e9ca93571e27e79dfb808e5d2e7967afa952b52e99c85f",
             dependencies=["meson", "ninja", "glib", "gstreamer", "gst-plugins-base"],
-            patches=["wasapideviceprovider-Add-support-for-dynamic-device-.patch"],
+            patches=[
+                "wasapideviceprovider-Add-support-for-dynamic-device-.patch",
+                "wasapisink-reduce-buffer-latency.patch",
+            ],
         )
         self.add_param("-Dcurl=disabled")
         self.add_param("-Dcurl-ssh2=disabled")

--- a/patches/gst-plugins-bad/wasapisink-reduce-buffer-latency.patch
+++ b/patches/gst-plugins-bad/wasapisink-reduce-buffer-latency.patch
@@ -1,0 +1,46 @@
+partial backport of https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/1529
+
+wasapisink: reduce buffer latency in shared low-latency mode
+
+cap WASAPI buffer usage at the period size, as there is no need to
+fill the WASAPI buffer beyond the first device period. the ringbuffer
+thread has an entire period to wake up and refill the buffer before
+WASAPI will consume it again. the default buffer size is 25ms, which
+introduces 15ms of extra latency beyond the 10ms default period.
+
+diff --git a/sys/wasapi/gstwasapisink.c b/sys/wasapi/gstwasapisink.c
+--- a/sys/wasapi/gstwasapisink.c
++++ b/sys/wasapi/gstwasapisink.c
+@@ -473,6 +473,9 @@ gst_wasapi_sink_get_can_frames (GstWasapiSink * self)
+   GST_DEBUG_OBJECT (self, "%i unread frames (padding)", n_frames_padding);
+ 
+   /* We can write out these many frames */
++  if (n_frames_padding > self->buffer_frame_count) {
++    return 0;
++  }
+   return self->buffer_frame_count - n_frames_padding;
+ }
+ 
+@@ -515,6 +518,13 @@ gst_wasapi_sink_prepare (GstAudioSink * asink, GstAudioRingBufferSpec * spec)
+       "frames, bpf is %i bytes, rate is %i Hz", self->buffer_frame_count,
+       devicep_frames, bpf, rate);
+ 
++  /* In low-latency shared mode, restrict buffer to one device period */
++  if (self->low_latency && self->sharemode == AUDCLNT_SHAREMODE_SHARED) {
++    self->buffer_frame_count = MIN (self->buffer_frame_count, devicep_frames);
++    GST_INFO_OBJECT (self, "low-latency buffer size capped at %i frames",
++        self->buffer_frame_count);
++  }
++
+   /* Actual latency-time/buffer-time will be different now */
+   spec->segsize = devicep_frames * bpf;
+ 
+@@ -672,7 +682,7 @@ gst_wasapi_sink_write (GstAudioSink * asink, gpointer data, guint length)
+       goto err;
+     }
+ 
+-    if (can_frames == 0) {
++    while (can_frames == 0) {
+       dwWaitResult = WaitForMultipleObjects (2, event_handle, FALSE, INFINITE);
+       if (dwWaitResult != WAIT_OBJECT_0 && dwWaitResult != WAIT_OBJECT_0 + 1) {
+         GST_ERROR_OBJECT (self, "Error waiting for event handle: %x",


### PR DESCRIPTION
This patch for wasapisink reduces output delay due to excessive buffering by up to 15ms, in low-latency mode only. The other half of the upstream pull request (adding a new min-period parameter) is left for future releases of gstreamer as an enhancement.

Proposed upstream as part of
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/1529
