### PR TITLE
Add Support for GTK4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 ![CI](https://github.com/wingtk/gvsbuild/workflows/CI/badge.svg)
 
 This python script helps you build a full [GTK](https://www.gtk.org/) library
-stack for Windows using Visual Studio.
+stack for Windows using Visual Studio. Currently, GTK 3 (3.20, 3.22, 3.24) and
+GTK 4 (4.6) are supported.
 
 The script supports multiple versions of Visual Studio - at the moment we are
 focusing on VS 2019, but we include projects for other versions, and we gladly
 accept patches.
 
-The script focuses on GTK and the surrounding ecosystem (e.g. GStreamer),
-however we are pretty liberal about adding more libraries to the script, with
-the disclaimer that each contributor is responsible for keeping the additional
-libraries up to date. For now the list of projects is simply defined in the
-[projects.py](https://github.com/wingtk/gvsbuild/blob/master/gvsbuild/projects.py)
-file. If the number of libraries increases, we will consider making this more
-configurable and easily extensible.
+The script focuses on GTK and the surrounding ecosystem (e.g. GStreamer).
+However, we are open to adding more libraries as long as the contributor takes
+on the responsibility for keeping it up to date. The supported projects are
+modules in the
+[projects](https://github.com/wingtk/gvsbuild/blob/master/gvsbuild/projects)
+directory.
 
 The script requires a working installation of [Visual Studio for Windows
 Desktop](http://www.visualstudio.com), [Python 3](https://www.python.org) and
@@ -111,6 +111,13 @@ In the same PowerShell terminal, execute:
 cd C:\gtk-build\github\gvsbuild
 python .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\tools\msys64 --gtk3-ver=3.24 gtk3
 ```
+
+Alternatively, if you want to build GTK 4, execute:
+```PowerShell
+cd C:\gtk-build\github\gvsbuild
+python .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\tools\msys64 gtk4 
+```
+
 Grab a coffee, the build will take a few minutes to complete.
 
 #### Add GTK to Your Path

--- a/gvsbuild/projects/__init__.py
+++ b/gvsbuild/projects/__init__.py
@@ -32,7 +32,7 @@ from gvsbuild.projects.gstreamer import (
     GStreamer,
     Orc,
 )
-from gvsbuild.projects.gtk import Gtk, Gtk320, Gtk322, Gtk324
+from gvsbuild.projects.gtk import Gtk, Gtk4, Gtk320, Gtk322, Gtk324
 from gvsbuild.projects.gtksourceview import GtkSourceView
 from gvsbuild.projects.harfbuzz import Harfbuzz
 from gvsbuild.projects.hicolor_icon_theme import HicolorIconTheme

--- a/gvsbuild/projects/graphene.py
+++ b/gvsbuild/projects/graphene.py
@@ -26,8 +26,8 @@ class Graphene(Tarball, Meson):
         Meson.__init__(
             self,
             "graphene",
-            archive_url="https://github.com/ebassi/graphene/archive/refs/tags/1.10.4.tar.gz",
-            hash="d73861aceda1adf13c1fbb588ce8a3b4f632bd8d41e4635d4c70e00595d85c4d",
+            archive_url="https://github.com/ebassi/graphene/archive/refs/tags/1.10.6.tar.gz",
+            hash="7eba972751d404316a9b59a7c1e0782de263c3cf9dd5ebf1503ba9b8354cc948",
             dependencies=["ninja", "meson", "pkg-config", "glib"],
         )
         if self.opts.enable_gi:
@@ -36,7 +36,6 @@ class Graphene(Tarball, Meson):
         else:
             enable_gi = "disabled"
 
-        self.add_param("-Dbenchmarks=false")
         self.add_param("-Dintrospection={}".format(enable_gi))
 
     def build(self):

--- a/gvsbuild/projects/gtk.py
+++ b/gvsbuild/projects/gtk.py
@@ -95,7 +95,7 @@ class Gtk320(Project_gtk_base):
             self,
             "gtk3",
             prj_dir="gtk3-20",
-            archive_url="http://ftp.acc.umu.se/pub/GNOME/sources/gtk+/3.20/gtk+-3.20.10.tar.xz",
+            archive_url="https://download.gnome.org/sources/gtk%2B/3.20/gtk%2B-3.20.10.tar.xz",
             hash="e81da1af1c5c1fee87ba439770e17272fa5c06e64572939814da406859e56b70",
             dependencies=["atk", "gdk-pixbuf", "pango", "libepoxy"],
             patches=["gtk3-clip-retry-if-opened-by-others.patch"],
@@ -139,7 +139,7 @@ class Gtk322(Project_gtk_base):
             self,
             "gtk3",
             prj_dir="gtk3-22",
-            archive_url="http://ftp.acc.umu.se/pub/GNOME/sources/gtk+/3.22/gtk+-3.22.30.tar.xz",
+            archive_url="https://download.gnome.org/sources/gtk%2B/3.22/gtk%2B-3.22.30.tar.xz",
             hash="a1a4a5c12703d4e1ccda28333b87ff462741dc365131fbc94c218ae81d9a6567",
             dependencies=["atk", "gdk-pixbuf", "pango", "libepoxy"],
         )
@@ -203,3 +203,32 @@ class Gtk324(Tarball, Meson):
         Meson.build(self, meson_params="-Dtests=false -Ddemos=false -Dexamples=false")
 
         self.install(r".\COPYING share\doc\gtk3")
+
+
+@project_add
+class Gtk4(Tarball, Meson):
+    def __init__(self):
+        Project.__init__(
+            self,
+            "gtk4",
+            prj_dir="gtk4",
+            archive_url="https://download.gnome.org/sources/gtk/4.6/gtk-4.6.1.tar.xz",
+            hash="d85508d21cbbcd63d568a7862af5ecd63b978d7d5799cbe404c91d2389d0ec5f",
+            dependencies=["gdk-pixbuf", "pango", "libepoxy", "graphene"],
+            patches=[],
+        )
+        if self.opts.enable_gi:
+            self.add_dependency("gobject-introspection")
+            enable_gi = "enabled"
+        else:
+            enable_gi = "disabled"
+
+        self.add_param("-Dintrospection={}".format(enable_gi))
+
+    def build(self):
+        Meson.build(
+            self,
+            meson_params="-Dbuild-tests=false -Ddemos=false -Dbuild-examples=false -Dmedia-gstreamer=disabled",
+        )
+
+        self.install(r".\COPYING share\doc\gtk4")

--- a/gvsbuild/projects/librsvg.py
+++ b/gvsbuild/projects/librsvg.py
@@ -79,8 +79,8 @@ class Librsvg(Tarball, Project):
         Project.__init__(
             self,
             "librsvg",
-            archive_url="https://download.gnome.org/sources/librsvg/2.52/librsvg-2.52.2.tar.xz",
-            hash="03d2887c18ffb906e1a60f97fe46a7169f69aa28d6db5d285748f3618b093427",
+            archive_url="https://download.gnome.org/sources/librsvg/2.52/librsvg-2.52.6.tar.xz",
+            hash="a3f939a1e6a3a60408244632d0323f8c3b20eb4b7b000536e2e5bd93b8effaad",
             dependencies=[
                 "cargo",
                 "cairo",

--- a/gvsbuild/projects/pango.py
+++ b/gvsbuild/projects/pango.py
@@ -26,8 +26,8 @@ class Pango(Tarball, Meson):
         Project.__init__(
             self,
             "pango",
-            archive_url="https://download.gnome.org/sources/pango/1.48/pango-1.48.10.tar.xz",
-            hash="21e1f5798bcdfda75eabc4280514b0896ab56f656d4e7e66030b9a2535ecdc98",
+            archive_url="https://download.gnome.org/sources/pango/1.50/pango-1.50.4.tar.xz",
+            hash="f4ad63e87dc2b145300542a4fb004d07a9f91b34152fae0ddbe50ecdd851c162",
             dependencies=[
                 "ninja",
                 "meson",

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -108,13 +108,13 @@ class Tool_meson(Tool):
         Tool.__init__(
             self,
             "meson",
-            archive_url="https://github.com/mesonbuild/meson/archive/refs/tags/0.57.1.tar.gz",
-            archive_file_name="meson-0.57.1.tar.gz",
-            hash="0c043c9b5350e9087cd4f6becf6c0d10b1d618ca3f919e0dcca2cdf342360d5d",
+            archive_url="https://github.com/mesonbuild/meson/archive/refs/tags/0.59.4.tar.gz",
+            archive_file_name="meson-0.59.4.tar.gz",
+            hash="032276804563e78b037f55148e26bf890ed0101a8c9ea740a7c6682b33ef076a",
             dependencies=[
                 "python",
             ],
-            dir_part="meson-0.57.1",
+            dir_part="meson-0.59.4",
             exe_name="meson.py",
         )
 


### PR DESCRIPTION
This PR adds support for GTK4. In order to do that I also upgraded some other tools and projects including meson, pango, librsvg, and graphene.

In order to build it, I ran:
```
 python .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\tools\msys64 --enable-gi --py-wheel gobject-introspection gtk4 pycairo pygobject adwaita-icon-theme hicolor-icon-theme
```
The build was successful, and I tested a hello world app:

```
import gi
gi.require_version('Gtk', '4.0')
from gi.repository import Gtk

def on_activate(app):
    win = Gtk.ApplicationWindow(application=app, title="Hello GTK4")
    win.present()

app = Gtk.Application()
app.connect('activate', on_activate)

app.run(None)
```

![image](https://user-images.githubusercontent.com/10014976/155057664-a51d65a7-34de-4314-8fba-5e35666f4d11.png)

This PR closes #490.