### PR TITLE
Add support for VS2022 and Make Default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install visual studio tools
-        run: choco install visualstudio2019-workload-vctools
-
       # Temporarily move the preinstalled git, it causes errors related to cygwin.
       - name: Move git binary
         run: move "C:\Program Files\Git\usr\bin" "C:\Program Files\Git\usr\notbin"
@@ -50,7 +47,7 @@ jobs:
 
       - name: Build
         run: >
-          python .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\msys64 --enable-gi
+          python .\build.py build -p=x64 --vs-ver=17 --msys-dir=C:\msys64 --enable-gi
           --py-wheel --gtk3-ver=3.24 gtk3 graphene gobject-introspection pycairo
           pygobject adwaita-icon-theme hicolor-icon-theme gtksourceview4
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ stack for Windows using Visual Studio. Currently, GTK 3 (3.20, 3.22, 3.24) and
 GTK 4 (4.6) are supported.
 
 The script supports multiple versions of Visual Studio - at the moment we are
-focusing on VS 2019, but we include projects for other versions, and we gladly
+focusing on VS 2022, but we include projects for other versions, and we gladly
 accept patches.
 
 The script focuses on GTK and the surrounding ecosystem (e.g. GStreamer).
@@ -67,17 +67,17 @@ choco install msys2
 ### Building GTK
 
 First we will install the gvsbuild dependencies:
-1. Visual C++ build tools workload for Visual Studio 2019 Build Tools
+1. Visual C++ build tools workload for Visual Studio 2022 Build Tools
 2. Python
 
-#### Install Visual Studio 2019
+#### Install Visual Studio 2022
 With your admin PowerShell terminal:
 
 ```PowerShell
-choco install visualstudio2019-workload-vctools
+choco install visualstudio2022-workload-vctools
 ```
 
-Note: Visual Studio versions 2013 (not for all projects), 2015, 2017, and 2019 are currently supported.
+Note: Visual Studio versions 2013 (not for all projects), 2015, 2017, 2019, and 2022 are currently supported.
 
 #### Install the Latest Python
 
@@ -109,13 +109,13 @@ In the same PowerShell terminal, execute:
 
 ```PowerShell
 cd C:\gtk-build\github\gvsbuild
-python .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\tools\msys64 --gtk3-ver=3.24 gtk3
+python .\build.py build -p=x64 --vs-ver=17 --msys-dir=C:\tools\msys64 --gtk3-ver=3.24 gtk3
 ```
 
 Alternatively, if you want to build GTK 4, execute:
 ```PowerShell
 cd C:\gtk-build\github\gvsbuild
-python .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\tools\msys64 gtk4 
+python .\build.py build -p=x64 --vs-ver=17 --msys-dir=C:\tools\msys64 gtk4 
 ```
 
 Grab a coffee, the build will take a few minutes to complete.
@@ -128,12 +128,12 @@ $env:Path = "C:\gtk-build\gtk\x64\release\bin;" + $env:Path
 
 #### Other Options
 
- To build the 64-bit version with the Visual Studio 2019 (version 16) you need
+ To build the 64-bit version with the Visual Studio 2022 (version 17) you need
  also to tell the script the visual studio version, run:
 
  ```
  cd C:\gtk-build\github\gvsbuild
- python .\build.py build -p x64 --vs-ver 16 gtk3
+ python .\build.py build -p x64 --vs-ver 17 gtk3
  ```
 
  For more information about the possible commands run:

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -123,7 +123,7 @@ class Project(object):
 
     def _msbuild_make_search_replace(self, org_platform):
         """Return the search & replace strings (converted to bytes to update
-        the platfomrm Toolset version (v140, v141, ...) to use a new compiler,
+        the platform Toolset version (v140, v141, ...) to use a new compiler,
         e.g. to use vs2017 solution's files for vs2019.
 
         The '<PlatformToolset' at the beginning is missing to handle
@@ -132,6 +132,8 @@ class Project(object):
         """
 
         ver = self.builder.opts.vs_ver
+        if ver == "17":
+            dst_platform = "143"
         if ver == "16":
             dst_platform = "142"
         elif ver == "15":

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -102,6 +102,7 @@ class Builder(object):
             "14": "vs2015",
             "15": "vs2017",
             "16": "vs2019",
+            "17": "vs2022",
         }
 
         self.vs_ver_year = vs_zip_parts.get(opts.vs_ver, None)

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -115,6 +115,11 @@ def get_options(args):
                 r"C:\Program Files (x86)\Microsoft Visual Studio\2019"
             )
             opts._vs_path_auto = True
+        elif opts.vs_ver == "17":
+            opts.vs_install_path = (
+                r"C:\Program Files (x86)\Microsoft Visual Studio\2022"
+            )
+            opts._vs_path_auto = True
         else:
             opts.vs_install_path = (
                 r"C:\Program Files (x86)\Microsoft Visual Studio {}.0".format(
@@ -327,8 +332,8 @@ Examples:
     )
     p_build.add_argument(
         "--vs-ver",
-        default="12",
-        help="Visual Studio version 12 (vs2013), 14 (vs2015), 15 (vs2017), 16 (vs2019). Default is 12.",
+        default="17",
+        help="Visual Studio version 12 (vs2013), 14 (vs2015), 15 (vs2017), 16 (vs2019), 17 (vs2022). Default is 17.",
     )
     p_build.add_argument(
         "--vs-install-path",
@@ -348,7 +353,7 @@ Examples:
     p_build.add_argument(
         "--python-ver",
         default="3.10",
-        help="Python version to download and use for the build (3.10, 3.9, 3.8, 3.7, or the exact one, 3.5.2.1 or 3.8.0-a3.",
+        help="Python version to download and use for the build (3.10, 3.9, 3.8, 3.7, or the exact one, 3.10.2 or 3.8.0-a3.",
     )
     p_build.add_argument(
         "--python-dir",


### PR DESCRIPTION
Visual Studio 2022 has been out for a few months now, and it is installed by default on our CI runner. This PR adds support for it and switches it to the default version. This should speed up our CI builds by 6.5 minutes by not having to install vs2019 build tools.