### PR TITLE
Add MakeData target to the msbuild command in icu project

### DIFF
--- a/gvsbuild/projects/icu.py
+++ b/gvsbuild/projects/icu.py
@@ -48,7 +48,7 @@ class Icu(Tarball, Project):
                 replace,
             )
 
-        self.exec_msbuild(r"source\allinone\allinone.sln /t:cal")
+        self.exec_msbuild(r"source\allinone\allinone.sln /t:cal /t:MakeData")
 
         if self.builder.opts.configuration == "debug":
             self.install_pc_files("pc-files-debug")


### PR DESCRIPTION
Add target Makedata to get all the mapping data in the icudt.dll. 