### PR TITLE
Add command line parameter net-target-framework

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,34 @@
 repos:
-- repo: https://github.com/psf/black
-  rev: 21.12b0
-  hooks:
-  - id: black
-    language_version: python3
-- repo: https://github.com/PyCQA/flake8
-  rev: 4.0.1
-  hooks:
-    - id: flake8
-      additional_dependencies: [flake8-eradicate==1.2.0]
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
-  hooks:
-  - id: check-yaml
-- repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
-  hooks:
-  - id: isort
-    additional_dependencies: [toml]
-- repo: https://github.com/myint/docformatter
-  rev: v1.4
-  hooks:
-    - id: docformatter
-      args: [--in-place]
-- repo: https://github.com/asottile/pyupgrade
-  rev: v2.29.1
-  hooks:
-  - id: pyupgrade
-- repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.8.0.3
-  hooks:
-    - id: shellcheck
-      args: [--exclude, SC1017]
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+      language_version: python3
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-eradicate==1.2.0]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: check-yaml
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        additional_dependencies: [toml]
+  - repo: https://github.com/myint/docformatter
+    rev: v1.4
+    hooks:
+      - id: docformatter
+        args: [--in-place]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.8.0.4
+    hooks:
+      - id: shellcheck
+        args: [--exclude, SC1017]
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.1
+    hooks:
+      - id: pyupgrade

--- a/gvsbuild/projects/harfbuzz.py
+++ b/gvsbuild/projects/harfbuzz.py
@@ -29,6 +29,7 @@ class Harfbuzz(Tarball, Meson):
             archive_url="https://github.com/harfbuzz/harfbuzz/releases/download/4.1.0/harfbuzz-4.1.0.tar.xz",
             hash="f7984ff4241d4d135f318a93aa902d910a170a8265b7eaf93b5d9a504eed40c8",
             dependencies=["python", "freetype", "pkg-config", "glib"],
+            patches=["0001-meson-find-icu-using-pkgconfig.patch"],
         )
 
         if Project.opts.enable_gi:

--- a/gvsbuild/projects/icu.py
+++ b/gvsbuild/projects/icu.py
@@ -27,9 +27,9 @@ class Icu(Tarball, Project):
         Project.__init__(
             self,
             "icu",
-            archive_url="https://github.com/unicode-org/icu/releases/download/release-63-1/icu4c-63_1-src.zip",
-            hash="3d957deabf75e96c35918355eac4da3e728fc222b9b4bdb2663652f76ee51772",
-            version="63.1",
+            archive_url="https://github.com/unicode-org/icu/releases/download/release-70-1/icu4c-70_1-src.zip",
+            hash="0d41e13364af260e330fdc5d2d60531564108d6a1234209f5712f8d9693315a7",
+            version="70.1",
         )
 
     def build(self):

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -149,9 +149,7 @@ class Builder(object):
             )
 
         if self.opts.net_target_framework:
-            rt.append(
-                '/p:TargetFrameworks="{}"'.format(self.opts.net_target_framework)
-            )
+            rt.append('/p:TargetFrameworks="{}"'.format(self.opts.net_target_framework))
 
         if self.opts.msbuild_opts:
             rt.append(self.opts.msbuild_opts)

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -148,6 +148,11 @@ class Builder(object):
                 '/p:WindowsTargetPlatformVersion="{}"'.format(self.opts.win_sdk_ver)
             )
 
+        if self.opts.net_target_framework:
+            rt.append(
+                '/p:TargetFrameworks="{}"'.format(self.opts.net_target_framework)
+            )
+
         if self.opts.msbuild_opts:
             rt.append(self.opts.msbuild_opts)
 

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -49,6 +49,7 @@ def get_options(args):
     opts.vs_ver = args.vs_ver
     opts.vs_install_path = args.vs_install_path
     opts.win_sdk_ver = args.win_sdk_ver
+    opts.net_target_framework = args.net_target_framework
     opts.python_dir = args.python_dir
     opts.msys_dir = args.msys_dir
     opts.clean = args.clean
@@ -346,6 +347,11 @@ Examples:
         + "16299, 17134 or 17763 "
         + "depending on the VS version / installation's options. "
         + "If you don't specify one the scripts tries to locate the used one to pass the value to the msbuild command.",
+    )
+    p_build.add_argument(
+        "--net-target-framework",
+        default=None,
+        help=".net target framework. If set then TargetFrameworks parameter is passed down to msbuild with the specific target. i.e net45",
     )
     p_build.add_argument(
         "--python-ver",

--- a/patches/harfbuzz/0001-meson-find-icu-using-pkgconfig.patch
+++ b/patches/harfbuzz/0001-meson-find-icu-using-pkgconfig.patch
@@ -1,0 +1,36 @@
+From 472b784a6e074c229c1875935542aaf8a28cbf57 Mon Sep 17 00:00:00 2001
+From: Ignacio Casal Quinteiro <qignacio@amazon.com>
+Date: Tue, 29 Mar 2022 16:24:53 +0200
+Subject: [PATCH] meson: find icu using pkgconfig
+
+---
+ meson.build | 13 +++----------
+ 1 file changed, 3 insertions(+), 10 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 29d9fd583..5519f3fee 100644
+--- a/meson.build
++++ b/meson.build
+@@ -93,16 +93,9 @@ gobject_dep = dependency('gobject-2.0', required: get_option('gobject'))
+ graphite2_dep = dependency('graphite2', required: get_option('graphite2'))
+ graphite_dep = dependency('graphite2', required: get_option('graphite'))
+ 
+-if cpp.get_argument_syntax() == 'msvc'
+-  icu_dep = dependency('ICU',
+-                       required: get_option('icu'),
+-                       components: 'uc',
+-                       method: 'cmake')
+-else
+-  icu_dep = dependency('icu-uc',
+-                       required: get_option('icu'),
+-                       method: 'pkg-config')
+-endif
++icu_dep = dependency('icu-uc',
++                     required: get_option('icu'),
++                     method: 'pkg-config')
+ 
+ if icu_dep.found() and icu_dep.type_name() == 'pkgconfig'
+   icu_defs = icu_dep.get_variable(pkgconfig: 'DEFS', default_value: '').split()
+-- 
+2.25.1
+


### PR DESCRIPTION
This is to be able to pass down to msbuild the .Net target
framework i.e net45.

Currently this is needed in case you want to build icu