### PR TITLE
Restore build tools to correct directory with VS2022

### DIFF
--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -653,7 +653,7 @@ class Builder:
         log.start(f"Building project {proj.name} ({proj.version})")
         script_title(f"{proj.name} ({proj.version})")
 
-        proj.pkg_dir = proj.build_dir + "-rel"
+        proj.pkg_dir = f"{proj.build_dir}-rel"
         shutil.rmtree(proj.pkg_dir, ignore_errors=True)
         os.makedirs(proj.pkg_dir)
 
@@ -698,21 +698,8 @@ class Builder:
             # delta with the old
             new = cur - self.file_built
             if new:
-                # file presents, do the zip (with the version)
-                if proj.version.startswith("git/"):
-                    t_ver = proj.version[4:]
-                else:
-                    t_ver = proj.version
-
-                _t = [c if c.isalnum() else "_" for c in t_ver]
-                ver_part = "".join(_t)
-
-                zip_file = os.path.join(self.zip_dir, proj.prj_dir + "-" + ver_part)
-                self.make_zip(zip_file, new)
-                # use the current file set
-                self.file_built = cur
+                self.__build_zip(proj, new, cur)
             else:
-                # No file preentt
                 log.log(f"{proj.name}:zip not needed (tool?)")
 
         # Drop the mark file for all the projects that depends on this so we rebuild them
@@ -733,6 +720,16 @@ class Builder:
         script_title(None)
         log.end()
         return False
+
+    def __build_zip(self, proj, new, cur):
+        t_ver = proj.version[4:] if proj.version.startswith("git/") else proj.version
+        _t = [c if c.isalnum() else "_" for c in t_ver]
+        ver_part = "".join(_t)
+
+        zip_file = os.path.join(self.zip_dir, f"{proj.prj_dir}-{ver_part}")
+        self.make_zip(zip_file, new)
+        # use the current file set
+        self.file_built = cur
 
     def make_zip(self, name, files):
         make_zip(name, files, skip_spc=len(self.gtk_dir))

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -372,13 +372,7 @@ class Builder:
                 )
 
         add_opts = f" {opts.win_sdk_ver}" if opts.win_sdk_ver else ""
-        log.log(
-            'Running script "%s"%s'
-            % (
-                vcvars_bat,
-                add_opts,
-            )
-        )
+        log.log(f'Running script "{vcvars_bat}"{add_opts}')
         if not os.path.exists(vcvars_bat):
             if not exit_missing:
                 return None

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -269,9 +269,9 @@ class Builder:
         log.debug(f"patch: {self.patch}")
 
         if opts.python_dir and not Path.is_file(Path(opts.python_dir) / "python.exe"):
-                log.error_exit(
-                    f"Executable python.exe not found at '{self.opts.python_dir}'"
-                )
+            log.error_exit(
+                f"Executable python.exe not found at '{self.opts.python_dir}'"
+            )
         log.end()
 
     def _add_env(self, key, value, env, prepend=True, subst=False):
@@ -339,7 +339,7 @@ class Builder:
 
     def __extract_paths(self, res):
         log.message("")
-        log.message("Visual studio installation(s) found:")
+        log.message("Visual Studio installation(s) found:")
         paths = []
         for i in res:
             disp = i.get("displayName", "?")
@@ -412,6 +412,7 @@ class Builder:
             opts.vs_install_path = self.__find_vs_path_with_vs_version(
                 self.__dump_vs_loc()
             )
+        log.message(f"Using Visual Studio at {opts.vs_install_path}")
         output = self.__check_good_vs_install(opts, opts.vs_install_path, True)
 
         self.vs_env = {}

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -91,7 +91,7 @@ class Builder:
         self.x86 = opts.platform == "Win32"
         self.x64 = not self.x86
 
-        # Create the year version for Visual studio
+        # Create the year version for Visual Studio
         vs_zip_parts = {
             "12": "vs2013",
             "14": "vs2015",
@@ -389,6 +389,7 @@ class Builder:
                 add_opts,
             ),
             shell=True,
+            text=True,
         )
 
     def __find_vs_path_with_vs_version(self, paths):
@@ -416,15 +417,6 @@ class Builder:
         self.vs_env = {}
         dbg = log.debug_on()
         for line in output.splitlines():
-            # Python3 str is not bytes and no need to decode
-            if isinstance(line, bytes):
-                try:
-                    decoded_line = line.decode("utf-8")
-                except UnicodeDecodeError:
-                    log.message(f"Warning: utf-8 decode error on [{line}]")
-                    decoded_line = line.decode("utf-8", errors="replace")
-                line = decoded_line
-
             e = line.split("=", 1)
             if len(e) < 2:
                 log.debug(f"vs env: ignoring {line}")

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -417,9 +417,18 @@ class Builder:
                 "Looking for the Visual Studio version installed under %s ..."
                 % (opts.vs_install_path,)
             )
+
             for part in dir_parts:
+                if (
+                    part == "BuildTools"
+                    and opts.vs_install_path
+                    == r"C:\Program Files\Microsoft Visual Studio\2022"
+                ):
+                    vs_path = r"C:\Program Files (x86)\Microsoft Visual Studio\2022"
+                else:
+                    vs_path = opts.vs_install_path
                 output = self.__check_vs_single(
-                    opts, os.path.join(opts.vs_install_path, part), False
+                    opts, os.path.join(vs_path, part), False
                 )
                 if output:
                     log.log(f"Found '{part}'")

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -836,13 +836,7 @@ class Builder:
         data file as well as the resulting HTTPMessage object.
         """
 
-        if ssl_ignore_cert:
-            # ignore certificate
-            ssl_ctx = ssl._create_unverified_context()
-        else:
-            # let the library does the work
-            ssl_ctx = None
-
+        ssl_ctx = ssl._create_unverified_context() if ssl_ignore_cert else None
         msg = f"Opening {url} ..."
         print(msg, end="\r")
         with contextlib.closing(urlopen(url, None, context=ssl_ctx)) as fp:
@@ -857,14 +851,15 @@ class Builder:
             headers = fp.info()
 
             with open(filename, "wb") as tfp:
-                result = filename, headers
-                bs = 1024 * 8
-                size = -1
                 read = 0
                 blocknum = 0
-                if "content-length" in headers:
-                    size = int(headers["Content-Length"])
-
+                result = filename, headers
+                size = (
+                    int(headers["Content-Length"])
+                    if "content-length" in headers
+                    else -1
+                )
+                bs = 1024 * 8
                 reporthook(blocknum, bs, size)
 
                 while True:

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -96,27 +96,8 @@ def get_options(args):
             % (opts.patches_root_dir,)
         )
 
-    opts._vs_path_auto = False
     if not opts.tools_root_dir:
         opts.tools_root_dir = os.path.join(args.build_dir, "tools")
-    if not opts.vs_install_path:
-        if opts.vs_ver == "15":
-            opts.vs_install_path = (
-                r"C:\Program Files (x86)\Microsoft Visual Studio\2017"
-            )
-            opts._vs_path_auto = True
-        elif opts.vs_ver == "16":
-            opts.vs_install_path = (
-                r"C:\Program Files (x86)\Microsoft Visual Studio\2019"
-            )
-            opts._vs_path_auto = True
-        elif opts.vs_ver == "17":
-            opts.vs_install_path = r"C:\Program Files\Microsoft Visual Studio\2022"
-            opts._vs_path_auto = True
-        else:
-            opts.vs_install_path = (
-                f"C:\\Program Files (x86)\\Microsoft Visual Studio {opts.vs_ver}.0"
-            )
 
     if opts.python_dir is None and not opts.same_python:
         opts._load_python = True


### PR DESCRIPTION
With Visual Studio 2022, Build Tools (CLI version) is installed in C:\Program Files (x86), but the all the other version are installed in C:\Program Files. This PR checks changes the directory to the x86 version when BuildTools is looked for.

In order to do that, if `--vs-install-dir` is not set, then gvsbuild will now use vswhere to find the installed version of Visual Studio. If multiple versions are found, then it uses `--vs-ver` to select the right one.