### PR TITLE
Remove Mercurial Support

### DIFF
--- a/gvsbuild/utils/base_builders.py
+++ b/gvsbuild/utils/base_builders.py
@@ -20,7 +20,6 @@
 import os
 import shutil
 
-from .base_expanders import MercurialRepo
 from .base_project import Project
 from .simple_ui import log
 from .utils import _rmtree_error_handler
@@ -151,11 +150,6 @@ class CmakeProject(Project):
             self.builder.exec_vs("nmake /nologo", working_dir=work_dir)
             if do_install:
                 self.builder.exec_vs("nmake /nologo install", working_dir=work_dir)
-
-
-class MercurialCmakeProject(MercurialRepo, CmakeProject):
-    def __init__(self, name, **kwargs):
-        CmakeProject.__init__(self, name, **kwargs)
 
 
 class Rust(Project):

--- a/gvsbuild/utils/base_expanders.py
+++ b/gvsbuild/utils/base_expanders.py
@@ -15,7 +15,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-"""Various downloader / unpacker (tar, git, hg, ...)"""
+"""Various downloader / unpacker (tar, git, ...)"""
 
 import hashlib
 import os
@@ -258,19 +258,6 @@ class Tarball:
                     arcname="patches/" + os.path.basename(p),
                 )
 
-        log.end()
-
-
-class MercurialRepo:
-    def unpack(self):
-        log.start_verbose(f"(hg) Cloning {self.repo_url} to {self.build_dir}")
-        self.exec_cmd(f"hg clone {self.repo_url} {self.build_dir}-tmp")
-        shutil.move(self.build_dir + "-tmp", self.build_dir)
-        log.end()
-
-    def update_build_dir(self):
-        log.start_verbose(f"(hg) Updating directory {self.build_dir}")
-        self.exec_cmd("hg pull -u", working_dir=self.build_dir)
         log.end()
 
 


### PR DESCRIPTION
Mercurial is not used by any project, so removing support for it as a base builder