### PR TITLE
Make x64 the default platform

### DIFF
--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -317,9 +317,9 @@ Examples:
     p_build.add_argument(
         "-p",
         "--platform",
-        default="x86",
+        default="x64",
         choices=["x86", "x64"],
-        help="Platform to build for, x86 or x64. Default is x86.",
+        help="Platform to build for, x86 or x64. Default is x64.",
     )
     p_build.add_argument(
         "-c",


### PR DESCRIPTION
I think 32-bit Windows is now a rare or niche platform these days. This PR changes the default platform to x64.