### PR TITLE
Improve outdated functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ choco install vcredist2013
 
 Similar to other packages, you can build OpenSSL by executing:
 ```
-python .\build.py build openssl
+python .\build.py build openssl1
 ```
 
 ## Dependency Graph

--- a/gvsbuild/projects/__init__.py
+++ b/gvsbuild/projects/__init__.py
@@ -66,7 +66,7 @@ from gvsbuild.projects.lz4 import Lz4
 from gvsbuild.projects.mit_kerberos import Kerberos
 from gvsbuild.projects.nghttp2 import Nghttp2
 from gvsbuild.projects.openh264 import OpenH264
-from gvsbuild.projects.openssl import OpenSSL
+from gvsbuild.projects.openssl import OpenSSL1
 from gvsbuild.projects.opus import Opus
 from gvsbuild.projects.pango import Pango
 from gvsbuild.projects.pixman import Pixman

--- a/gvsbuild/projects/__init__.py
+++ b/gvsbuild/projects/__init__.py
@@ -52,7 +52,7 @@ from gvsbuild.projects.libmicrohttpd import Libmicrohttpd
 from gvsbuild.projects.libpng import Libpng
 from gvsbuild.projects.libpsl import Libpsl
 from gvsbuild.projects.librsvg import Librsvg, LibrsvgLegacy
-from gvsbuild.projects.libsoup import Libsoup, Libsoup3
+from gvsbuild.projects.libsoup import Libsoup2, Libsoup3
 from gvsbuild.projects.libssh import Libssh, Libssh2
 from gvsbuild.projects.libtiff import Libtiff4
 from gvsbuild.projects.libuv import Libuv

--- a/gvsbuild/projects/cyrus_sasl.py
+++ b/gvsbuild/projects/cyrus_sasl.py
@@ -27,7 +27,7 @@ class CyrusSasl(Tarball, Project):
             "cyrus-sasl",
             hash="9e8035c12d419209ea60584d5efa51d042c3ed44b450b9d173d5504b222df9f1",
             archive_url="https://github.com/wingtk/cyrus-sasl/releases/download/cyrus-sasl-lmdb-2.1.28/cyrus-sasl-2.1.28.tar.xz",
-            dependencies=["lmdb", "openssl", "mit-kerberos"],
+            dependencies=["lmdb", "openssl1", "mit-kerberos"],
             patches=[
                 "0001-fix-snprintf-macro.patch",
                 "0001-Add-MIT-Kerberos-as-GSSAPI-provider.patch",

--- a/gvsbuild/projects/freerdp.py
+++ b/gvsbuild/projects/freerdp.py
@@ -31,7 +31,7 @@ class FreeRDP(Tarball, CmakeProject):
             dependencies=[
                 "cmake",
                 "ninja",
-                "openssl",
+                "openssl1",
                 "openh264",
                 "ffmpeg",
                 "x264",

--- a/gvsbuild/projects/glib.py
+++ b/gvsbuild/projects/glib.py
@@ -48,7 +48,7 @@ class GLibNetworking(Tarball, Meson):
             "glib-networking",
             archive_url="https://download.gnome.org/sources/glib-networking/2.72/glib-networking-2.72.0.tar.xz",
             hash="100aaebb369285041de52da422b6b716789d5e4d7549a3a71ba587b932e0823b",
-            dependencies=["pkg-config", "ninja", "meson", "glib", "openssl"],
+            dependencies=["pkg-config", "ninja", "meson", "glib", "openssl1"],
             patches=[
                 "0001-Do-not-load-certificates-from-default-paths-on-MacOS.patch",
                 "0002-Loading-certificates-from-Windows-root-and-ca-stores.patch",

--- a/gvsbuild/projects/libarchive.py
+++ b/gvsbuild/projects/libarchive.py
@@ -37,7 +37,7 @@ class Libarchive(Tarball, CmakeProject):
                 "win-iconv",
                 "zlib",
                 "lz4",
-                "openssl",
+                "openssl1",
                 "libxml2",
             ],
             patches=["0001-ZIP-reader-fix-possible-out-of-bounds-read-in-zipx_l.patch"],

--- a/gvsbuild/projects/libsoup.py
+++ b/gvsbuild/projects/libsoup.py
@@ -21,11 +21,11 @@ from gvsbuild.utils.base_project import Project, project_add
 
 
 @project_add
-class Libsoup(Tarball, Meson):
+class Libsoup2(Tarball, Meson):
     def __init__(self):
         Project.__init__(
             self,
-            "libsoup",
+            "libsoup2",
             archive_url="https://download.gnome.org/sources/libsoup/2.74/libsoup-2.74.2.tar.xz",
             hash="f0a427656e5fe19e1df71c107e88dfa1b2e673c25c547b7823b6018b40d01159",
             dependencies=[
@@ -53,7 +53,7 @@ class Libsoup(Tarball, Meson):
     def build(self):
         Meson.build(self)
 
-        self.install(r".\COPYING share\doc\libsoup")
+        self.install(r".\COPYING share\doc\libsoup2")
 
 
 @project_add

--- a/gvsbuild/projects/libssh.py
+++ b/gvsbuild/projects/libssh.py
@@ -28,7 +28,7 @@ class Libssh(Tarball, CmakeProject):
             "libssh",
             archive_url="https://www.libssh.org/files/0.9/libssh-0.9.3.tar.xz",
             hash="2c8b5f894dced58b3d629f16f3afa6562c20b4bdc894639163cf657833688f0c",
-            dependencies=["zlib", "openssl", "cmake", "ninja"],
+            dependencies=["zlib", "openssl1", "cmake", "ninja"],
         )
 
     def build(self):

--- a/gvsbuild/projects/openssl.py
+++ b/gvsbuild/projects/openssl.py
@@ -20,11 +20,11 @@ from gvsbuild.utils.base_project import Project, project_add
 
 
 @project_add
-class OpenSSL(Tarball, Project):
+class OpenSSL1(Tarball, Project):
     def __init__(self):
         Project.__init__(
             self,
-            "openssl",
+            "openssl1",
             archive_url="https://www.openssl.org/source/openssl-1.1.1n.tar.gz",
             hash="40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a",
             dependencies=[

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -265,7 +265,7 @@ class Tool_python(Tool):
             version = "3.10.4"
 
         name = "pythonx86" if self.opts.x86 else "python"
-        t_id = f"{name}.{self.version}"
+        t_id = f"{name}.{version}"
         dest_dir = os.path.join(self.opts.tools_root_dir, t_id)
         # directory to use for the .exe
         self.tool_path = os.path.join(dest_dir, "tools")
@@ -289,7 +289,7 @@ class Tool_python(Tool):
             # nuget
             nuget = Project.get_tool_executable("nuget")
             # Install python
-            cmd = f"{nuget} install {name} -Version {self.version} -OutputDirectory {self.opts.tools_root_dir}"
+            cmd = f"{nuget} install {name} -Version {version} -OutputDirectory {self.opts.tools_root_dir}"
 
             subprocess.check_call(cmd, shell=True)
             py = os.path.join(self.tool_path, "python.exe")

--- a/gvsbuild/utils/base_tool.py
+++ b/gvsbuild/utils/base_tool.py
@@ -52,10 +52,7 @@ class Tool(Project):
         self.unpack()
 
     def get_path(self):
-        if self.tool_path:
-            return self.tool_path
-        else:
-            return self.build_dir
+        return self.tool_path or self.build_dir
 
     def get_executable(self):
         if self.full_exe:

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -275,6 +275,7 @@ def do_outdated(args):
                 "libssh2": "libssh2/libssh2",
                 "libtiff-4": "https://gitlab.com/libtiff/libtiff",
                 "libxml2": "https://gitlab.gnome.org/GNOME/libxml2",
+                "orc": "https://gitlab.freedesktop.org/gstreamer/orc",
                 "pango": "https://gitlab.gnome.org/GNOME/pango",
                 "pixman": "https://gitlab.freedesktop.org/pixman/pixman",
                 "pkg-config": "pkgconf",

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -238,31 +238,64 @@ def do_outdated(args):
     try:
         for project in projects:
             # glib-py-wrapper is vendored in gvsbuild
-            if project[0] == "glib-py-wrapper":
+            if project[0] == "glib-py-wrapper" or not project[1]:
                 continue
             name_and_major = seperate_name_and_major_version(project[0])
-            repo_list = [
-                f"https://gitlab.gnome.org/GNOME/{name_and_major[0]}",
-                f"https://gitlab.freedesktop.org/{name_and_major[0]}/{name_and_major[0]}",
-                name_and_major[0],
-            ]
+            repos = {
+                "adwaita-icon-theme": "https://gitlab.gnome.org/GNOME/adwaita-icon-theme",
+                "atk": "https://gitlab.gnome.org/GNOME/atk",
+                "boringssl": "https://github.com/google/boringssl",
+                "clutter": "https://gitlab.gnome.org/GNOME/clutter",
+                "cogl": "https://gitlab.gnome.org/Archive/cogl",
+                "emeus": "https://github.com/ebassi/emeus",
+                "fontconfig": "https://gitlab.freedesktop.org/fontconfig/fontconfig",
+                "freetype": "https://gitlab.freedesktop.org/freetype/freetype",
+                "gdk-pixbuf": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
+                "gettext": "autotools-mirror/gettext",
+                "glib": "https://gitlab.gnome.org/GNOME/glib",
+                "glib-networking": "https://gitlab.gnome.org/GNOME/glib-networking",
+                "glib-py-wrapper": "https://gitlab.gnome.org/GNOME/glib-py-wrapper",
+                "gobject-introspection": "https://gitlab.gnome.org/GNOME/gobject-introspection",
+                "gsettings-desktop-schemas": "https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas",
+                "gtk2": "https://gitlab.gnome.org/GNOME/gtk",
+                "gtk3": "https://gitlab.gnome.org/GNOME/gtk",
+                "gtk4": "https://gitlab.gnome.org/GNOME/gtk",
+                "gtksourceview4": "https://gitlab.gnome.org/GNOME/gtksourceview",
+                "gtksourceview5": "https://gitlab.gnome.org/GNOME/gtksourceview",
+                "hicolor-icon-theme": "https://gitlab.freedesktop.org/xdg/default-icon-theme",
+                "json-glib": "https://gitlab.gnome.org/GNOME/json-glib",
+                "libcurl": "https://github.com/curl/curl",
+                "libmicrohttpd": "https://github.com/Karlson2k/libmicrohttpd",
+                "libsoup2": "https://gitlab.gnome.org/GNOME/libsoup",
+                "libsoup3": "https://gitlab.gnome.org/GNOME/libsoup",
+                "libssh": "libssh/libssh-mirror",
+                "libssh2": "libssh2/libssh2",
+                "libtiff-4": "https://gitlab.com/libtiff/libtiff",
+                "libxml2": "https://gitlab.gnome.org/GNOME/libxml2",
+                "pango": "https://gitlab.gnome.org/GNOME/pango",
+                "pixman": "https://gitlab.freedesktop.org/pixman/pixman",
+                "pkg-config": "pkgconf",
+                "pygobject": "https://gitlab.gnome.org/GNOME/pygobject",
+                "wing": "https://gitlab.gnome.org/GNOME/wing",
+            }
             try:
-                for repo in repo_list:
-                    if name_and_major[1]:
-                        latest_version = lastversion.latest(
-                            repo=repo, major=name_and_major[1]
-                        )
-                    else:
-                        latest_version = lastversion.latest(
-                            repo=repo,
-                        )
-                    if latest_version and latest_version > packaging.version.parse(
-                        project[1]
-                    ):
-                        print(
-                            f"\t{project[0]:<{Project.name_len}} {project[1]:<45} {str(latest_version):<45}"
-                        )
-                        break
+                repo = repos.get(project[0], project[0])
+                if name_and_major[1] and project[0] != "nghttp2":
+                    latest_version = lastversion.latest(
+                        repo=repo, major=name_and_major[1]
+                    )
+                else:
+                    latest_version = lastversion.latest(
+                        repo=repo,
+                    )
+                if not latest_version:
+                    print(
+                        f"\t{project[0]:<{Project.name_len}} {project[1]:<45} {'No release found':<45}"
+                    )
+                elif latest_version > packaging.version.parse(project[1]):
+                    print(
+                        f"\t{project[0]:<{Project.name_len}} {project[1]:<45} {str(latest_version):<45}"
+                    )
             except packaging.version.InvalidVersion:
                 print(f"Project {project[0]} does not have a valid version")
     except lastversion.utils.ApiCredentialsError:

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -232,7 +232,8 @@ def do_outdated(args):
 
     Project.add_all()
     projects = get_project_by_type(ProjectType.PROJECT)
-    print("Looking for projects that are out-of-date, please submit a PR!")
+    projects.extend(get_project_by_type(ProjectType.TOOL))
+    print("Looking for projects and tools that are out-of-date, please submit a PR!")
     print(f"\t{'Project Name':<{Project.name_len}} {'Current':<45} {'Latest':<45}")
     try:
         for project in projects:
@@ -565,7 +566,9 @@ Examples:
     # check
     # ==============================================================================
 
-    p_outdated = subparsers.add_parser("outdated", help="list out of date projects")
+    p_outdated = subparsers.add_parser(
+        "outdated", help="list out of date projects and tools"
+    )
     p_outdated.set_defaults(func=do_outdated)
 
     return parser

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -216,7 +216,10 @@ def do_list(args):
     sys.exit(0)
 
 
-def seperate_name_and_major_version(name: str) -> tuple[str, Optional[str]]:
+def separate_name_and_major_version(name: str) -> tuple[str, Optional[str]]:
+    # Exceptions where ending with a simple digit is part of the library name
+    if name in {"nghttp2", "ssh2", "libxml2", "libtiff-4"}:
+        return name, None
     # https://regex101.com/r/1c4iLx/2
     m = re.search(r"([a-z-]*\d{3}|[a-z-]*\d{0})(\d$)?", name)
     return m[1], m[2]
@@ -240,7 +243,7 @@ def do_outdated(args):
             # glib-py-wrapper is vendored in gvsbuild
             if project[0] == "glib-py-wrapper" or not project[1]:
                 continue
-            name_and_major = seperate_name_and_major_version(project[0])
+            name_and_major = separate_name_and_major_version(project[0])
             repos = {
                 "adwaita-icon-theme": "https://gitlab.gnome.org/GNOME/adwaita-icon-theme",
                 "atk": "https://gitlab.gnome.org/GNOME/atk",
@@ -256,8 +259,8 @@ def do_outdated(args):
                 "glib-networking": "https://gitlab.gnome.org/GNOME/glib-networking",
                 "glib-py-wrapper": "https://gitlab.gnome.org/GNOME/glib-py-wrapper",
                 "gobject-introspection": "https://gitlab.gnome.org/GNOME/gobject-introspection",
+                "graphene": "ebassi/graphene",
                 "gsettings-desktop-schemas": "https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas",
-                "gtk2": "https://gitlab.gnome.org/GNOME/gtk",
                 "gtk3": "https://gitlab.gnome.org/GNOME/gtk",
                 "gtk4": "https://gitlab.gnome.org/GNOME/gtk",
                 "gtksourceview4": "https://gitlab.gnome.org/GNOME/gtksourceview",
@@ -279,8 +282,8 @@ def do_outdated(args):
                 "wing": "https://gitlab.gnome.org/GNOME/wing",
             }
             try:
-                repo = repos.get(project[0], project[0])
-                if name_and_major[1] and project[0] != "nghttp2":
+                repo = repos.get(project[0], name_and_major[0])
+                if name_and_major[1]:
                     latest_version = lastversion.latest(
                         repo=repo, major=name_and_major[1]
                     )

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -228,7 +228,7 @@ def separate_name_and_major_version(name: str) -> tuple[str, Optional[str]]:
 def do_outdated(args):
     try:
         import lastversion
-        import packaging
+        from packaging import version
     except ImportError:
         print("Please pip install -r requirements.txt in your Python environment")
         sys.exit(0)
@@ -295,11 +295,11 @@ def do_outdated(args):
                     print(
                         f"\t{project[0]:<{Project.name_len}} {project[1]:<45} {'No release found':<45}"
                     )
-                elif latest_version > packaging.version.parse(project[1]):
+                elif version.parse(str(latest_version)) > version.parse(project[1]):
                     print(
                         f"\t{project[0]:<{Project.name_len}} {project[1]:<45} {str(latest_version):<45}"
                     )
-            except packaging.version.InvalidVersion:
+            except version.InvalidVersion:
                 print(f"Project {project[0]} does not have a valid version")
     except lastversion.utils.ApiCredentialsError:
         print("Set GITHUB_API_TOKEN=xxxxxxxxxxxxxxx environmental variable")


### PR DESCRIPTION
- Adds tools to list of things checked if they are outdated
- Explicitly define repo names if not on GitHub to ensure the right versions are found and reduce querying GNOME and freedesktop gitlab servers for every package
- Rename openssl to openssl1 for better version parsing, and leaves room for us to add the 3.x version of openssl to gvsbuild
- Rename libsoup to libsoup2
- Fixes an issue where packages ending in a single digit were not being searched for correctly
- Outputs that a release can't be located in the repo has no releases or tags