### PR TITLE
Revert protobuf updates

### DIFF
--- a/gvsbuild/projects/protobuf.py
+++ b/gvsbuild/projects/protobuf.py
@@ -26,8 +26,8 @@ class Protobuf(Tarball, CmakeProject):
         Project.__init__(
             self,
             "protobuf",
-            archive_url="https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/protobuf-cpp-3.20.0.tar.gz",
-            hash="4cfa0276b3ba4e8bb239326213fc9acfb6ac100cdfc55aeec30a551525547f9e",
+            archive_url="https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protobuf-cpp-3.15.8.tar.gz",
+            hash="9b57647b898e45253c98fae35146f6a5e9e788817d29019f9280270c951a0038",
             dependencies=[
                 "cmake",
                 "zlib",

--- a/gvsbuild/projects/protobuf.py
+++ b/gvsbuild/projects/protobuf.py
@@ -53,8 +53,8 @@ class ProtobufC(Tarball, CmakeProject):
         Project.__init__(
             self,
             "protobuf-c",
-            archive_url="https://github.com/protobuf-c/protobuf-c/releases/download/v1.4.0/protobuf-c-1.4.0.tar.gz",
-            hash="26d98ee9bf18a6eba0d3f855ddec31dbe857667d269bc0b6017335572f85bbcb",
+            archive_url="https://github.com/protobuf-c/protobuf-c/releases/download/v1.3.3/protobuf-c-1.3.3.tar.gz",
+            hash="22956606ef50c60de1fabc13a78fbc50830a0447d780467d3c519f84ad527e78",
             dependencies=[
                 "cmake",
                 "protobuf",


### PR DESCRIPTION
The new protobuf version adds a regression when building protobuf-c. We need to investigate why protobuf-c does not build but in the meantime I will just revert these 2 updates