### PR TITLE
Fix missing stack.prop

### DIFF
--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -87,7 +87,9 @@ def get_options(args):
     if not opts.export_dir:
         opts.export_dir = os.path.join(args.build_dir, "export")
     if not opts.patches_root_dir:
-        opts.patches_root_dir = os.path.join(sys.path[0], "patches")
+        opts.patches_root_dir = os.path.join(
+            opts.build_dir, "github", "gvsbuild", "patches"
+        )
     prop_file = os.path.join(opts.patches_root_dir, "stack.props")
     if not os.path.isfile(prop_file):
         log.error_exit(

--- a/gvsbuild/utils/parser.py
+++ b/gvsbuild/utils/parser.py
@@ -26,7 +26,7 @@ from typing import Any, Tuple, Union
 from .base_project import Options, Project, ProjectType
 from .builder import Builder
 from .simple_ui import log
-from .utils import ordered_set
+from .utils import get_project_root, ordered_set
 
 
 def get_options(args):
@@ -87,9 +87,7 @@ def get_options(args):
     if not opts.export_dir:
         opts.export_dir = os.path.join(args.build_dir, "export")
     if not opts.patches_root_dir:
-        opts.patches_root_dir = os.path.join(
-            opts.build_dir, "github", "gvsbuild", "patches"
-        )
+        opts.patches_root_dir = os.path.join(get_project_root(), "patches")
     prop_file = os.path.join(opts.patches_root_dir, "stack.props")
     if not os.path.isfile(prop_file):
         log.error_exit(

--- a/gvsbuild/utils/utils.py
+++ b/gvsbuild/utils/utils.py
@@ -20,6 +20,7 @@ import re
 import shutil
 import stat
 import time
+from pathlib import Path
 
 from .simple_ui import log
 
@@ -142,3 +143,7 @@ def python_find_libs_dir(org_dir):
         return cur
 
     return None
+
+
+def get_project_root() -> Path:
+    return Path(__file__).parent.parent.parent


### PR DESCRIPTION
Set the patches directory based on the build dir if it isn't set using `--patches-root-dir`. Fixes #589.