### PR TITLE
gdk-pixbuf: Use 'builtin_loaders=all'

### DIFF
--- a/gvsbuild/projects/gdk_pixbuf.py
+++ b/gvsbuild/projects/gdk_pixbuf.py
@@ -34,6 +34,7 @@ class GdkPixbuf(Tarball, Meson):
                 "meson",
                 "python",
                 "libtiff-4",
+                "libjpeg-turbo",
                 "glib",
                 "libpng",
             ],
@@ -44,7 +45,7 @@ class GdkPixbuf(Tarball, Meson):
         else:
             enable_gi = "disabled"
 
-        self.add_param("-Dnative_windows_loaders=true")
+        self.add_param("-Dbuiltin_loaders=all")
         self.add_param(f"-Dintrospection={enable_gi}")
         self.add_param("-Dman=false")
 


### PR DESCRIPTION
Replace 'native_windows_loaders=true' with 'builtin_loaders=all' to fix issue of Pixbuf.new_from_file crashes loading gif, ico or bmp images