### PR TITLE
Allow prerelease Msvc

### DIFF
--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -325,7 +325,7 @@ class Builder:
         if os.path.exists(json_file):
             os.remove(json_file)
 
-        cmd = f'"{vswhere}" -all -products * -format json >{json_file}'
+        cmd = f'"{vswhere}" -all -prelease -products * -format json >{json_file}'
         self.exec_cmd(cmd)
 
         try:

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -325,7 +325,7 @@ class Builder:
         if os.path.exists(json_file):
             os.remove(json_file)
 
-        cmd = f'"{vswhere}" -all -prelease -products * -format json >{json_file}'
+        cmd = f'"{vswhere}" -all -prerelease -products * -format json >{json_file}'
         self.exec_cmd(cmd)
 
         try:


### PR DESCRIPTION
Checked on my system.

Before: 

```cmd
gvsbuild build gtk4
```

```python
Cleaning up the build environment
Checking msys tool
Using C:\Msys64 for msys installation
Checking Msvc tool
Traceback (most recent call last):
File "C:\Users\mavad\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 196, in _run_module_as_main
return _run_code(code, main_globals, None,
File "C:\Users\mavad\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 86, in _run_code                                                                                                               exec(code, run_globals)
File "C:\Users\mavad\Documents\GitHub\gvsbuild\.venv\Scripts\gvsbuild.exe\__main__.py", line 7, in <module>
File "C:\Users\mavad\Documents\GitHub\gvsbuild\.venv\lib\site-packages\gvsbuild\main.py", line 45, in build
args.func(args)
File "C:\Users\mavad\Documents\GitHub\gvsbuild\.venv\lib\site-packages\gvsbuild\utils\parser.py", line 162, in do_build
builder = Builder(opts)
File "C:\Users\mavad\Documents\GitHub\gvsbuild\.venv\lib\site-packages\gvsbuild\utils\builder.py", line 126, in __init__
self.__check_vs(opts)
File "C:\Users\mavad\Documents\GitHub\gvsbuild\.venv\lib\site-packages\gvsbuild\utils\builder.py", line 412, in __check_vs
opts.vs_install_path = self.__find_vs_path_with_vs_version(
File "C:\Users\mavad\Documents\GitHub\gvsbuild\.venv\lib\site-packages\gvsbuild\utils\builder.py", line 396, in __find_vs_path_with_vs_version
for path in paths:
TypeError: 'NoneType' object is not iterable
```