### PR TITLE
Fix Unicode Decode Error by not saving the vswhere json

### DIFF
--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -321,23 +321,17 @@ class Builder:
             log.log(f"Could not find vswhere executable ({vswhere})")
             return
 
-        json_file = "vs-found.json"
-        if os.path.exists(json_file):
-            os.remove(json_file)
-
-        cmd = (
-            f'"{vswhere}" -all -prerelease -products * -format json -utf8 >{json_file}'
+        completed_process = subprocess.run(
+            [f"{vswhere}", "-all", "-products", "*", "-format", "json", "-utf8"],
+            text=True,
+            capture_output=True,
         )
-        self.exec_cmd(cmd)
-
         try:
-            with open(json_file, encoding="utf-8") as fi:
-                vs_installs = json.load(fi)
-        except (IOError, OSError) as e:
-            log.log(f"Exception reading vswhere result file ({e})")
-
-        if vs_installs:
+            completed_process.check_returncode()
+            vs_installs = json.loads(completed_process.stdout)
             return self.__extract_paths(vs_installs)
+        except subprocess.CalledProcessError as e:
+            log.log(f"Unable to call vswhere.exe to find Visual Studio with error {e}")
 
     def __extract_paths(self, res):
         log.message("")


### PR DESCRIPTION
Issue #624 is getting codec errors when saving and loading json. Piping to a file may result in it getting saved using the default codec instead of utf-8. Since the vswhere.json file isn't needed to be saved, directly load the result of the vswhere command instead of saving it.