### PR TITLE
Fix filenames for release upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,13 @@ jobs:
         shell: cmd
       - name: Create Source Dist and Wheel
         run: poetry build
-      - name: Upload gaphor-${{ steps.setup_and_test.outputs.version }}.tar.gz
+      - name: Upload gvsbuild-${{ github.event.release.tag_name }}.tar.gz
         uses: actions/upload-artifact@v3
         if: github.event_name == 'release'
         with:
           name: gvsbuild-${{ github.event.release.tag_name }}.tar.gz
-          path: dist/gaphor-${{ github.event.release.tag_name }}.tar.gz
-      - name: Upload gaphor-${{ github.event.release.tag_name }}-py3-none-any.whl
+          path: dist/gvsbuild-${{ github.event.release.tag_name }}.tar.gz
+      - name: Upload gvsbuild-${{ github.event.release.tag_name }}-py3-none-any.whl
         uses: actions/upload-artifact@v3
         if: github.event_name == 'release'
         with:


### PR DESCRIPTION
This fixes #685 by replacing some wrong filenames that should have been gvsbuild instead of gaphor.