### PR TITLE
glib-networking: downgrade to 2.72.2, fix compilation with glib 2.72.4

### DIFF
--- a/gvsbuild/projects/glib.py
+++ b/gvsbuild/projects/glib.py
@@ -47,8 +47,8 @@ class GLibNetworking(Tarball, Meson):
         Project.__init__(
             self,
             "glib-networking",
-            archive_url="https://download.gnome.org/sources/glib-networking/2.74/glib-networking-2.74.0.tar.xz",
-            hash="1f185aaef094123f8e25d8fa55661b3fd71020163a0174adb35a37685cda613b",
+            archive_url="https://download.gnome.org/sources/glib-networking/2.74/glib-networking-2.72.2.tar.xz",
+            hash="cd2a084c7bb91d78e849fb55d40e472f6d8f6862cddc9f12c39149359ba18268",
             dependencies=["pkg-config", "ninja", "meson", "glib", "openssl"],
             patches=[
                 "0001-Mark-strings-for-translation-and-translate-just-in-e.patch",


### PR DESCRIPTION
glib-networking 2.74 depends on glib-2.74 since glib-networking commit 1d4cf09f41d9ca8a6.

Downgrade glib-networking to 2.72.2 which can be compiled with the current glib version 2.72.4.

Fix compilation since 86b80f9dc.