### PR TITLE
libtiff: rebase and readd patch to drop library postfix, fix consumpt…

### DIFF
--- a/gvsbuild/patches/libtiff-4/0001-cmake-remove-.d-postfix.patch
+++ b/gvsbuild/patches/libtiff-4/0001-cmake-remove-.d-postfix.patch
@@ -1,0 +1,26 @@
+From 2a6ad9c579262b57e357cbe2d765d9da5188cf62 Mon Sep 17 00:00:00 2001
+From: Ignacio Casal Quinteiro <qignacio@amazon.com>
+Date: Fri, 19 Nov 2021 14:53:30 +0100
+Subject: [PATCH] cmake: remove .d postfix
+
+Drop .d postfix from libraries, since this will make consuming libraries
+fail. Probably this should be made configurable.
+---
+ cmake/WindowsSupport.cmake | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/cmake/WindowsSupport.cmake b/cmake/WindowsSupport.cmake
+index 8cfe7ae3..7a8b423a 100644
+--- a/cmake/WindowsSupport.cmake
++++ b/cmake/WindowsSupport.cmake
+@@ -25,7 +25,6 @@
+ 
+ # Debug postfix
+ if(MSVC)
+-    set(CMAKE_DEBUG_POSTFIX "d")
+ # disable deprecation warnings
+     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+ # suppress deprecation warning for MSVC POSIX names
+-- 
+2.36.1.windows.1
+

--- a/gvsbuild/projects/libtiff.py
+++ b/gvsbuild/projects/libtiff.py
@@ -29,6 +29,7 @@ class Libtiff4(Tarball, CmakeProject):
             archive_url="http://download.osgeo.org/libtiff/tiff-4.4.0.tar.gz",
             hash="917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed",
             dependencies=["cmake", "ninja", "libjpeg-turbo"],
+            patches=["0001-cmake-remove-.d-postfix.patch"],
         )
 
     def build(self):


### PR DESCRIPTION
…ion of debug libraries

This partially reverts commit ad05668a6b35ad0c4cb3162aa46a363ea961fac2.

The patch strips the .d from the generated debug libraries, it is needed to be able to consume the debug libraries from other libraries (e.g. from libgxps).

Fix build with command:
py .\build.py build libgxps --vs-ver 15 --configuration debug