### PR TITLE
Rename list-projects to list, simplify list test

### DIFF
--- a/gvsbuild/list.py
+++ b/gvsbuild/list.py
@@ -21,7 +21,7 @@ import typer
 from gvsbuild.utils.base_project import Project, ProjectType
 
 
-def list_projects(
+def list_(
     projects_names: list[str] = typer.Argument(None, help="The projects to list"),
     project_type: ProjectType = typer.Option(
         None,

--- a/gvsbuild/main.py
+++ b/gvsbuild/main.py
@@ -23,7 +23,7 @@
 import typer
 
 from gvsbuild.deps import deps
-from gvsbuild.list_projects import list_projects
+from gvsbuild.list import list_
 
 try:
     import gvsbuild.utils.utils  # noqa: F401
@@ -47,7 +47,7 @@ from gvsbuild.outdated import outdated
 app = typer.Typer(help="Build GTK for Windows")
 app.command(help="")(build)
 app.command(help="")(outdated)
-app.command(help="")(list_projects)
+app.command(help="", name="list")(list_)
 app.command(help="")(deps)
 
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -15,117 +15,20 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-projects = [
-    "adwaita-icon-theme",
-    "atk",
-    "boringssl",
-    "cairo",
-    "check-libs",
-    "clutter",
-    "cogl",
-    "cyrus-sasl",
-    "dcv-color-primitives",
-    "emeus",
-    "enchant",
-    "ffmpeg",
-    "fontconfig",
-    "freerdp",
-    "freetype",
-    "fribidi",
-    "gdk-pixbuf",
-    "gettext",
-    "glib",
-    "glib-networking",
-    "glib-py-wrapper",
-    "gobject-introspection",
-    "graphene",
-    "gsettings-desktop-schemas",
-    "gst-plugins-bad",
-    "gst-plugins-base",
-    "gst-plugins-good",
-    "gst-python",
-    "gstreamer",
-    "gtk2",
-    "gtk3",
-    "gtk4",
-    "gtksourceview4",
-    "gtksourceview5",
-    "harfbuzz",
-    "hello-world",
-    "hicolor-icon-theme",
-    "icu",
-    "json-c",
-    "json-glib",
-    "leveldb",
-    "lgi",
-    "libadwaita",
-    "libarchive",
-    "libcroco",
-    "libcurl",
-    "libepoxy",
-    "libffi",
-    "libgxps",
-    "libjpeg-turbo",
-    "libmicrohttpd",
-    "libpng",
-    "libpsl",
-    "librsvg",
-    "libsoup2",
-    "libsoup3",
-    "libssh",
-    "libssh2",
-    "libtiff-4",
-    "libuv",
-    "libvpx",
-    "libxml2",
-    "libyuv",
-    "libzip",
-    "lmdb",
-    "luajit",
-    "lz4",
-    "mit-kerberos",
-    "nghttp2",
-    "nv-codec-headers",
-    "openh264",
-    "openssl",
-    "opus",
-    "orc",
-    "pango",
-    "pixman",
-    "pkg-config",
-    "portaudio",
-    "protobuf",
-    "protobuf-c",
-    "pycairo",
-    "pygobject",
-    "sqlite",
-    "win-iconv",
-    "wing",
-    "x264",
-    "zlib",
-]
-tools = [
-    "cargo",
-    "cmake",
-    "go",
-    "meson",
-    "msys2",
-    "nasm",
-    "ninja",
-    "nuget",
-    "perl",
-    "python",
-    "yasm",
-]
-groups = ["all", "gtk3-full", "tools", "tools-check"]
+import gvsbuild.groups  # noqa: F401
+import gvsbuild.projects  # noqa: F401
+import gvsbuild.tools  # noqa: F401
+from gvsbuild.utils.base_project import Project, ProjectType
 
 
 def test_list(typer_app, runner):
+    Project.add_all()
+    projects = Project.list_projects()
+
     result = runner.invoke(typer_app, ["list"])
     assert result.exit_code == 0
-    for group in groups:
-        assert group in result.stdout
-    for project in projects:
-        assert project in result.stdout
-    for tool in tools:
-        assert tool in result.stdout
+    for project_type in [ProjectType.GROUP, ProjectType.PROJECT, ProjectType.TOOL]:
+        for project_name in [
+            project.name for project in projects if project.type == project_type
+        ]:
+            assert project_name in result.stdout

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -120,8 +120,8 @@ tools = [
 groups = ["all", "gtk3-full", "tools", "tools-check"]
 
 
-def test_list_projects(typer_app, runner):
-    result = runner.invoke(typer_app, ["list-projects"])
+def test_list(typer_app, runner):
+    result = runner.invoke(typer_app, ["list"])
     assert result.exit_code == 0
     for group in groups:
         assert group in result.stdout

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,7 +22,7 @@ def test_main_help(typer_app, runner):
     assert "build" in result.stdout
     assert "outdated" in result.stdout
     assert "deps" in result.stdout
-    assert "list-projects" in result.stdout
+    assert "list" in result.stdout
 
 
 def test_wrong_command(typer_app, runner):


### PR DESCRIPTION
Rename `list-projects` to `list` for consistency/ergonomic reasons, also simplify list tests to avoid information duplication.