### PR TITLE
Apply Gtk3 patch for GdkWin32Selection

### DIFF
--- a/gvsbuild/patches/gtk3/gdkwin32-fix-subclassing-for-gdkwin32selection.patch
+++ b/gvsbuild/patches/gtk3/gdkwin32-fix-subclassing-for-gdkwin32selection.patch
@@ -1,0 +1,27 @@
+From 8f0d580cf94708f4f2719831ccd625816637af00 Mon Sep 17 00:00:00 2001
+From: Luca Bacci <luca.bacci982@gmail.com>
+Date: Mon, 26 Sep 2022 14:28:03 +0200
+Subject: [PATCH] GdkWin32: Fix subclassing for GdkWin32Selection
+
+Fixes https://gitlab.gnome.org/GNOME/gtk/-/issues/5207
+---
+ gdk/win32/gdkselection-win32.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gdk/win32/gdkselection-win32.h b/gdk/win32/gdkselection-win32.h
+index c3ed6cd45e..0b024894eb 100644
+--- a/gdk/win32/gdkselection-win32.h
++++ b/gdk/win32/gdkselection-win32.h
+@@ -129,7 +129,8 @@ typedef struct _GdkWin32SelectionClass GdkWin32SelectionClass;
+  */
+ struct _GdkWin32Selection
+ {
+-  GObject *parent_instance;
++  GObject parent_instance;
++
+   GHashTable *sel_prop_table;
+   GdkSelProp *dropfiles_prop;
+   /* We store the owner of each selection in this table. Obviously, this only
+-- 
+GitLab
+

--- a/gvsbuild/patches/gtk4/gdkwin32-fix-subclassing-for-gdkwin32clipdrop.patch
+++ b/gvsbuild/patches/gtk4/gdkwin32-fix-subclassing-for-gdkwin32clipdrop.patch
@@ -1,0 +1,26 @@
+From e2219858ae46158b899314c57a21013739d644e6 Mon Sep 17 00:00:00 2001
+From: Luca Bacci <luca.bacci982@gmail.com>
+Date: Mon, 26 Sep 2022 14:34:24 +0200
+Subject: [PATCH] GdkWin32: Fix subclassing for GdkWin32Clipdrop
+
+Fixes https://gitlab.gnome.org/GNOME/gtk/-/issues/5207
+---
+ gdk/win32/gdkclipdrop-win32.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdk/win32/gdkclipdrop-win32.h b/gdk/win32/gdkclipdrop-win32.h
+index 1be94dad8f..b71ed00107 100644
+--- a/gdk/win32/gdkclipdrop-win32.h
++++ b/gdk/win32/gdkclipdrop-win32.h
+@@ -126,7 +126,7 @@ typedef BOOL (WINAPI * GetUpdatedClipboardFormatsFunc)(
+  */
+ struct _GdkWin32Clipdrop
+ {
+-  GObject *parent_instance;
++  GObject parent_instance;
+ 
+   /* interned strings for well-known image formats */
+   const char **known_pixbuf_formats;
+-- 
+GitLab
+

--- a/gvsbuild/projects/gtk.py
+++ b/gvsbuild/projects/gtk.py
@@ -120,7 +120,9 @@ class Gtk4(Tarball, Meson):
             archive_url="https://download.gnome.org/sources/gtk/4.8/gtk-4.8.1.tar.xz",
             hash="5ce8d8de98a23bd0c8eca1a61094e1c009b5f009dcbd60b45e990a8db1b742fd",
             dependencies=["gdk-pixbuf", "pango", "libepoxy", "graphene"],
-            patches=[],
+            patches=[
+                "gdkwin32-fix-subclassing-for-gdkwin32clipdrop.patch",
+            ],
         )
         if self.opts.enable_gi:
             self.add_dependency("gobject-introspection")

--- a/gvsbuild/projects/gtk.py
+++ b/gvsbuild/projects/gtk.py
@@ -93,6 +93,7 @@ class Gtk3(Tarball, Meson):
             dependencies=["atk", "gdk-pixbuf", "pango", "libepoxy"],
             patches=[
                 "gtk_update_icon_cache.patch",
+                "gdkwin32-fix-subclassing-for-gdkwin32selection.patch",
             ],
         )
         if self.opts.enable_gi:


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/gtk/-/issues/5207. Even though the crash is reported with GLib 2.74.0, the code was definitely wrong and the fix is trivial. Backport the patch until the next minor release.