### PR TITLE
Remove External Python as a Tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: move "C:\Program Files\Git\usr\bin" "C:\Program Files\Git\usr\notbin"
         shell: cmd
       - name: Test with tox
-        run: tox
+        run: poetry run tox
       - name: Restore git binary
         run: move "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
         shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 
 env:
-  python_version: '3.10'
+  python_version: '3.11'
 
 name: CI
 
@@ -26,6 +26,46 @@ jobs:
           python-version: ${{ env.python_version }}
       - name: Lint with Pre-commit
         uses: pre-commit/action@v3.0.0
+
+  test:
+    needs: lint
+    name: Test with Python ${{ matrix.python-version }}
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    runs-on: windows-latest
+    timeout-minutes: 60
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set up Python
+        uses: actions/setup-python@v4.3.0
+        with:
+          python-version: ${{ env.python_version }}
+      - name: Use Python Dependency Cache
+        uses: actions/cache@v3.0.11
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: ${{ runner.os }}-poetry-
+      - name: Install Poetry
+        run: python -m pip install poetry==1.2.2
+      - name: Configure Poetry
+        run: poetry config virtualenvs.in-project true
+      - name: Install Python Dependencies
+        run: poetry install
+      # Temporarily move the preinstalled git, it causes errors related to cygwin.
+      - name: Move git binary
+        run: move "C:\Program Files\Git\usr\bin" "C:\Program Files\Git\usr\notbin"
+        shell: cmd
+      - name: Test with tox
+        run: tox
+      - name: Restore git binary
+        run: move "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
+        shell: cmd
 
   build:
     needs: lint
@@ -50,7 +90,7 @@ jobs:
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
           restore-keys: ${{ runner.os }}-poetry-
       - name: Install Poetry
-        run: python -m pip install poetry==1.2.1
+        run: python -m pip install poetry==1.2.2
       - name: Configure Poetry
         run: poetry config virtualenvs.in-project true
       - name: Install Python Dependencies
@@ -59,8 +99,6 @@ jobs:
       - name: Move git binary
         run: move "C:\Program Files\Git\usr\bin" "C:\Program Files\Git\usr\notbin"
         shell: cmd
-      - name: Test
-        run: poetry run pytest
       - name: Build
         run: >
           poetry run gvsbuild build --enable-gi --py-wheel gtk3 graphene glib-networking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.3.0
         with:
-          python-version: ${{ env.python_version }}
+          python-version: ${{ matrix.python-version }}
       - name: Use Python Dependency Cache
         uses: actions/cache@v3.0.11
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   python_version: '3.11'
+  poetry_version: '1.2.2'
 
 name: CI
 
@@ -52,17 +53,20 @@ jobs:
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
           restore-keys: ${{ runner.os }}-poetry-
       - name: Install Poetry
-        run: python -m pip install poetry==1.2.2
+        run: python -m pip install poetry==${{ env.poetry_version }}
       - name: Configure Poetry
         run: poetry config virtualenvs.in-project true
       - name: Install Python Dependencies
         run: poetry install
+      - name: Install dependencies
+        run: |
+          pip install tox tox-gh-actions
       # Temporarily move the preinstalled git, it causes errors related to cygwin.
       - name: Move git binary
         run: move "C:\Program Files\Git\usr\bin" "C:\Program Files\Git\usr\notbin"
         shell: cmd
       - name: Test with tox
-        run: poetry run tox
+        run: tox
       - name: Restore git binary
         run: move "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
         shell: cmd
@@ -90,7 +94,7 @@ jobs:
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
           restore-keys: ${{ runner.os }}-poetry-
       - name: Install Poetry
-        run: python -m pip install poetry==1.2.2
+        run: python -m pip install poetry==${{ env.poetry_version }}
       - name: Configure Poetry
         run: poetry config virtualenvs.in-project true
       - name: Install Python Dependencies

--- a/README.md
+++ b/README.md
@@ -87,9 +87,7 @@ Download and install the latest version of Python:
 
 Note: If you are going to install Python using an alternative means, like the
 official Windows installers, we suggest to install Python in C:\Python3x, for
-example C:\Python310. Alternatively you can use the `--python-dir` option to
-tell the script the correct location of your Python installation. Other Python
-distributions like [Miniconda
+example C:\Python310. Other Python distributions like [Miniconda
 3](https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe)
 should also work.
 

--- a/gvsbuild/build.py
+++ b/gvsbuild/build.py
@@ -27,10 +27,6 @@ from gvsbuild.utils.utils import ordered_set
 
 def __get_projects_to_build(opts):
     to_build = ordered_set()
-    if opts._load_python:
-        # We use nuget to download & install the python needed for the build so we put it at the beginning
-        opts.projects.insert(0, "python")
-
     for name in opts.projects:
         p = Project.get_project(name)
         if opts.deps:
@@ -168,22 +164,6 @@ def build(
         help=".net target framework version. If set then TargetFrameworkVersion parameter is passed down to "
         "msbuild with the specific version. i.e v4.6.2",
         rich_help_panel=".NET Options",
-    ),
-    python_ver: PythonVersion = typer.Option(
-        PythonVersion.py310,
-        help="Python version to download and use for the build",
-        rich_help_panel="Python Options",
-    ),
-    python_dir: Path = typer.Option(
-        None,
-        help="The directory containing the Python you want to use for the build of the projects (not the one used "
-        "to run the script).",
-        rich_help_panel="Python Options",
-    ),
-    same_python: bool = typer.Option(
-        False,
-        help="If set, the python used to run the script will be used to build the projects.",
-        rich_help_panel="Python Options",
     ),
     check_hash: bool = typer.Option(
         False,
@@ -368,7 +348,6 @@ def build(
         opts.git_expand_dir = str(archives_download_dir / "git-exp")
     opts.net_target_framework = net_target_framework
     opts.net_target_framework_version = net_target_framework_version
-    opts.python_dir = python_dir
     opts.msys_dir = msys_dir
     opts.clean = clean
     opts.msbuild_opts = msbuild_opts
@@ -390,8 +369,6 @@ def build(
     opts.log_single = log_single
     opts.cargo_opts = cargo_opts
     opts.ninja_opts = ninja_opts
-    opts.python_ver = python_ver.value
-    opts.same_python = same_python
     opts.capture_out = capture_out
     opts.print_out = print_out
 
@@ -403,8 +380,6 @@ def build(
             f"Missing 'stack.props' file on directory {opts.patches_root_dir}.\n"
             "Wrong or missing --patches-root-dir option?"
         )
-    if opts.python_dir is None and not opts.same_python:
-        opts._load_python = True
 
     opts.projects = projects
     Project.opts = opts

--- a/gvsbuild/build.py
+++ b/gvsbuild/build.py
@@ -16,6 +16,7 @@
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
 from enum import Enum
 from pathlib import Path
+from typing import List
 
 import typer
 
@@ -92,7 +93,7 @@ class PythonVersion(str, Enum):
 
 
 def build(
-    projects: list[str] = typer.Argument(..., help="The project to build"),
+    projects: List[str] = typer.Argument(..., help="The project to build"),
     platform: Platform = typer.Option(Platform.x64, help="The platform to build for"),
     configuration: Configuration = typer.Option(
         Configuration.release, help="The configuration to build for"
@@ -189,7 +190,7 @@ def build(
         help="Command line options to pass to msbuild.",
         rich_help_panel="Options to Pass to Build Systems",
     ),
-    skip: list[str] = typer.Option(
+    skip: List[str] = typer.Option(
         None,
         help="List of projects to skip. i.e gtk3, glib, ...",
         rich_help_panel="Skip and Cleanup Options",

--- a/gvsbuild/deps.py
+++ b/gvsbuild/deps.py
@@ -14,6 +14,8 @@
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 
+from typing import List
+
 import typer
 
 """gvsbuild deps print / .gv graph."""
@@ -234,7 +236,7 @@ def deps(
     invert: bool = typer.Option(
         False, help="Invert the dependencies", rich_help_panel="Graphing Options"
     ),
-    skip: list[str] = typer.Option(
+    skip: List[str] = typer.Option(
         None,
         help="A comma separated list of projects not to graph",
         rich_help_panel="Graphing Options",

--- a/gvsbuild/groups.py
+++ b/gvsbuild/groups.py
@@ -38,7 +38,6 @@ class Group_Tools(Group):
                 "ninja",
                 "nuget",
                 "perl",
-                "python",
                 "yasm",
             ],
         )

--- a/gvsbuild/list.py
+++ b/gvsbuild/list.py
@@ -15,6 +15,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
 import json
+from typing import List
 
 import typer
 
@@ -22,7 +23,7 @@ from gvsbuild.utils.base_project import Project, ProjectType
 
 
 def list_(
-    projects_names: list[str] = typer.Argument(None, help="The projects to list"),
+    projects_names: List[str] = typer.Argument(None, help="The projects to list"),
     project_type: ProjectType = typer.Option(
         None,
         "--type",

--- a/gvsbuild/projects/adwaita_icon_theme.py
+++ b/gvsbuild/projects/adwaita_icon_theme.py
@@ -31,7 +31,6 @@ class AdwaitaIconTheme(Tarball, Project):
             hash="2e3ac77d32a6aa5554155df37e8f0a0dd54fc5a65fd721e88d505f970da32ec6",
             dependencies=[
                 "librsvg",
-                "python",
             ],
         )
 

--- a/gvsbuild/projects/cogl.py
+++ b/gvsbuild/projects/cogl.py
@@ -27,7 +27,7 @@ class Cogl(Tarball, Project):
             "cogl",
             archive_url="https://download.gnome.org/sources/cogl/1.22/cogl-1.22.8.tar.xz",
             hash="a805b2b019184710ff53d0496f9f0ce6dcca420c141a0f4f6fcc02131581d759",
-            dependencies=["python", "glib", "cairo", "pango", "gdk-pixbuf"],
+            dependencies=["glib", "cairo", "pango", "gdk-pixbuf"],
             patches=[
                 "001-cogl-missing-symbols.patch",
                 "002-cogl-pango-missing-symbols.patch",

--- a/gvsbuild/projects/gdk_pixbuf.py
+++ b/gvsbuild/projects/gdk_pixbuf.py
@@ -32,7 +32,6 @@ class GdkPixbuf(Tarball, Meson):
                 "ninja",
                 "pkg-config",
                 "meson",
-                "python",
                 "libtiff-4",
                 "libjpeg-turbo",
                 "glib",

--- a/gvsbuild/projects/gettext.py
+++ b/gvsbuild/projects/gettext.py
@@ -29,7 +29,7 @@ class Gettext(Tarball, Project):
             "gettext",
             archive_url="http://ftp.gnu.org/pub/gnu/gettext/gettext-0.21.tar.xz",
             hash="d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192",
-            dependencies=["python", "win-iconv"],
+            dependencies=["win-iconv"],
             patches=[
                 "gettext-runtime-c99.patch",
                 "gettext-tools-c99.patch",

--- a/gvsbuild/projects/gobject_introspection.py
+++ b/gvsbuild/projects/gobject_introspection.py
@@ -14,6 +14,8 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
+import sys
+from pathlib import Path
 
 from gvsbuild.utils.base_builders import Meson
 from gvsbuild.utils.base_expanders import Tarball
@@ -48,7 +50,7 @@ class GObjectIntrospection(Tarball, Meson):
         self.builder.mod_env("LIB", r".\girepository")
         self.builder.mod_env("PATH", r".\girepository")
         # For linking the _giscanner.pyd extension module when using a virtualenv
-        py_dir = Project.get_tool_path("python")
+        py_dir = Path(sys.executable).parent
         py_libs = python_find_libs_dir(py_dir)
         if py_libs:
             log.debug(f"Python library path is [{py_libs}]")

--- a/gvsbuild/projects/gsettings_desktop_schemas.py
+++ b/gvsbuild/projects/gsettings_desktop_schemas.py
@@ -28,7 +28,7 @@ class GSettingsDesktopSchemas(Tarball, Meson):
             "gsettings-desktop-schemas",
             archive_url="https://download.gnome.org/sources/gsettings-desktop-schemas/43/gsettings-desktop-schemas-43.0.tar.xz",
             hash="5d5568282ab38b95759d425401f7476e56f8cbf2629885587439f43bd0b84bbe",
-            dependencies=["meson", "ninja", "pkg-config", "python", "glib"],
+            dependencies=["meson", "ninja", "pkg-config", "glib"],
         )
         if self.opts.enable_gi:
             self.add_dependency("gobject-introspection")

--- a/gvsbuild/projects/gtksourceview.py
+++ b/gvsbuild/projects/gtksourceview.py
@@ -28,7 +28,7 @@ class GtkSourceView4(Tarball, Meson):
             "gtksourceview4",
             archive_url="https://download.gnome.org/sources/gtksourceview/4.8/gtksourceview-4.8.4.tar.xz",
             hash="7ec9d18fb283d1f84a3a3eff3b7a72b09a10c9c006597b3fbabbb5958420a87d",
-            dependencies=["python", "meson", "ninja", "gtk3", "pkg-config"],
+            dependencies=["meson", "ninja", "gtk3", "pkg-config"],
         )
         if Project.opts.enable_gi:
             self.add_dependency("gobject-introspection")
@@ -49,7 +49,7 @@ class GtkSourceView5(Tarball, Meson):
             "gtksourceview5",
             archive_url="https://download.gnome.org/sources/gtksourceview/5.6/gtksourceview-5.6.1.tar.xz",
             hash="659d9cc9d034a114f07e7e134ee80d77dec0497cb1516ae5369119c2fcb9da16",
-            dependencies=["python", "meson", "ninja", "gtk4", "pkg-config"],
+            dependencies=["meson", "ninja", "gtk4", "pkg-config"],
         )
         if Project.opts.enable_gi:
             self.add_dependency("gobject-introspection")

--- a/gvsbuild/projects/harfbuzz.py
+++ b/gvsbuild/projects/harfbuzz.py
@@ -29,7 +29,7 @@ class Harfbuzz(Tarball, Meson):
             "harfbuzz",
             archive_url=f"https://github.com/harfbuzz/harfbuzz/releases/download/{self.version}/harfbuzz-{self.version}.tar.xz",
             hash="4a6ce097b75a8121facc4ba83b5b083bfec657f45b003cd5a3424f2ae6b4434d",
-            dependencies=["meson", "cmake", "python", "freetype", "pkg-config", "glib"],
+            dependencies=["meson", "cmake", "freetype", "pkg-config", "glib"],
         )
 
         if Project.opts.enable_gi:

--- a/gvsbuild/projects/json_glib.py
+++ b/gvsbuild/projects/json_glib.py
@@ -28,7 +28,7 @@ class JsonGLib(Tarball, Meson):
             "json-glib",
             archive_url="https://download.gnome.org/sources/json-glib/1.6/json-glib-1.6.6.tar.xz",
             hash="96ec98be7a91f6dde33636720e3da2ff6ecbb90e76ccaa49497f31a6855a490e",
-            dependencies=["meson", "ninja", "pkg-config", "python", "glib"],
+            dependencies=["meson", "ninja", "pkg-config", "glib"],
         )
         if self.opts.enable_gi:
             self.add_dependency("gobject-introspection")

--- a/gvsbuild/projects/libepoxy.py
+++ b/gvsbuild/projects/libepoxy.py
@@ -29,7 +29,7 @@ class Libepoxy(Tarball, Meson):
             archive_url="https://github.com/anholt/libepoxy/archive/refs/tags/1.5.10.tar.gz",
             hash="a7ced37f4102b745ac86d6a70a9da399cc139ff168ba6b8002b4d8d43c900c15",
             archive_filename="libepoxy-1.5.10.tar.gz",
-            dependencies=["python", "ninja", "meson"],
+            dependencies=["ninja", "meson"],
         )
 
     def build(self):

--- a/gvsbuild/projects/libffi.py
+++ b/gvsbuild/projects/libffi.py
@@ -29,7 +29,7 @@ class Libffi(GitRepo, Meson):
             repo_url="https://gitlab.freedesktop.org/gstreamer/meson-ports/libffi.git",
             fetch_submodules=False,
             tag="meson-3.2.9999.4",
-            dependencies=["python", "ninja", "meson"],
+            dependencies=["ninja", "meson"],
         )
 
     def build(self):

--- a/gvsbuild/projects/libpsl.py
+++ b/gvsbuild/projects/libpsl.py
@@ -29,7 +29,6 @@ class Libpsl(Tarball, Meson):
             archive_url="https://github.com/rockdaboot/libpsl/releases/download/0.21.1/libpsl-0.21.1.tar.gz",
             hash="ac6ce1e1fbd4d0254c4ddb9d37f1fa99dec83619c1253328155206b896210d4c",
             dependencies=[
-                "python",
                 "meson",
                 "ninja",
                 "pkg-config",

--- a/gvsbuild/projects/librsvg.py
+++ b/gvsbuild/projects/librsvg.py
@@ -14,6 +14,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
+import sys
 
 from gvsbuild.utils.base_expanders import Tarball
 from gvsbuild.utils.base_project import Project, project_add
@@ -43,7 +44,7 @@ class Librsvg(Tarball, Project):
 
         b_dir = f"{self.builder.working_dir}\\{self.name}\\win32"
 
-        cmd = f'nmake -f makefile.vc CFG={self.builder.opts.configuration} PREFIX={self.builder.gtk_dir} PYTHON={Project.get_tool_executable("python")} install'
+        cmd = f"nmake -f makefile.vc CFG={self.builder.opts.configuration} PREFIX={self.builder.gtk_dir} PYTHON={sys.executable} install"
 
         if Project.opts.enable_gi:
             cmd += " INTROSPECTION=1"

--- a/gvsbuild/projects/pycairo.py
+++ b/gvsbuild/projects/pycairo.py
@@ -29,7 +29,7 @@ class Pycairo(Tarball, Project):
             "pycairo",
             archive_url="https://github.com/pygobject/pycairo/releases/download/v1.21.0/pycairo-1.21.0.tar.gz",
             hash="251907f18a552df938aa3386657ff4b5a4937dde70e11aa042bc297957f4b74b",
-            dependencies=["cairo", "python"],
+            dependencies=["cairo"],
         )
 
     def build(self):

--- a/gvsbuild/projects/pygobject.py
+++ b/gvsbuild/projects/pygobject.py
@@ -29,7 +29,7 @@ class PyGObject(Tarball, Project):
             "pygobject",
             archive_url="https://download.gnome.org/sources/pygobject/3.42/pygobject-3.42.2.tar.xz",
             hash="ade8695e2a7073849dd0316d31d8728e15e1e0bc71d9ff6d1c09e86be52bc957",
-            dependencies=["python", "pycairo", "gobject-introspection", "libffi"],
+            dependencies=["pycairo", "gobject-introspection", "libffi"],
             patches=[
                 "pygobject_py3_8_load_dll.patch",
             ],

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -278,7 +278,7 @@ class ToolGo(Tool):
         self.full_exe = os.path.join(self.tool_path, "go.exe")
 
     def unpack(self):
-        # We download directly the exe file so we copy it on the tool directory ...
+        # We download directly the exe file, so we copy it to the tool directory
         self.mark_deps = extract_exec(
             self.archive_file,
             self.build_dir,

--- a/gvsbuild/utils/base_builders.py
+++ b/gvsbuild/utils/base_builders.py
@@ -19,6 +19,8 @@
 
 import os
 import shutil
+import sys
+from pathlib import Path
 
 from .base_project import Project
 from .simple_ui import log
@@ -69,8 +71,8 @@ class Meson(Project):
             add_opts += f" {meson_params}"
         # python meson.py src_dir ninja_build_dir --prefix gtk_bin options
         meson = Project.get_tool_executable("meson")
-        python = Project.get_tool_executable("python")
-        if " " in python:
+        python = Path(sys.executable)
+        if " " in str(python):
             python = f'"{python}"'
         cmd = f"{python} {meson} {self._get_working_dir()} {ninja_build} --prefix {self.builder.gtk_dir} {add_opts}"
 

--- a/gvsbuild/utils/base_expanders.py
+++ b/gvsbuild/utils/base_expanders.py
@@ -89,11 +89,7 @@ def extract_exec(
                 tarinfo.linkname = "/".join(tarinfo.linkname.split("/")[1:])
             yield tarinfo
 
-    if dir_part:
-        full_dest = os.path.join(dest_dir, dir_part)
-    else:
-        full_dest = dest_dir
-
+    full_dest = os.path.join(dest_dir, dir_part) if dir_part else dest_dir
     if check_mark:
         rd_file = read_mark_file(full_dest)
         wr_file = os.path.basename(src)

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -17,6 +17,7 @@
 
 """Base project class, used also for tools."""
 
+
 import datetime
 import os
 import re
@@ -39,7 +40,6 @@ class Options:
     def __init__(self):
         self.enable_gi = False
         self.ffmpeg_enable_gpl = False
-        self._load_python = False
         self.verbose = False
         self.debug = False
         self.platform = "x64"
@@ -54,7 +54,6 @@ class Options:
         self.win_sdk_ver = None
         self.net_target_framework = None
         self.net_target_framework_version = None
-        self.python_dir = None
         self.msys_dir = None
         self.clean = False
         self.msbuild_opts = None
@@ -74,8 +73,6 @@ class Options:
         self.log_single = False
         self.cargo_opts = None
         self.ninja_opts = None
-        self.python_ver = None
-        self.same_python = None
         self.capture_out = False
         self.print_out = False
         self.git_expand_dir = None

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -27,6 +27,7 @@ import re
 import shutil
 import ssl
 import subprocess
+import sys
 import time
 import traceback
 from pathlib import Path
@@ -267,11 +268,6 @@ class Builder:
             )
 
         log.debug(f"patch: {self.patch}")
-
-        if opts.python_dir and not Path.is_file(Path(opts.python_dir) / "python.exe"):
-            log.error_exit(
-                f"Executable python.exe not found at '{self.opts.python_dir}'"
-            )
         log.end()
 
     def _add_env(self, key, value, env, prepend=True, subst=False):
@@ -925,11 +921,9 @@ class Builder:
         if self.__project is not None:
             d["pkg_dir"] = self.__project.pkg_dir
             d["build_dir"] = self.__project.build_dir
-            # Add python & perl only if the project depends on them
-            p = Project.get_project("python")
-            if p in self.__project.all_dependencies:
-                python = Project.get_tool_path(p)
-                d["python_dir"] = python
+            python = Path(sys.executable).parent
+            d["python_dir"] = python
+            # Add perl only if the project depends on them
 
             p = Project.get_project("perl")
             if p in self.__project.all_dependencies:

--- a/gvsbuild/utils/simple_ui.py
+++ b/gvsbuild/utils/simple_ui.py
@@ -17,11 +17,12 @@
 
 """Simple user interface for info, log & debug messages."""
 
+
 import ctypes
 import datetime
 import os
 import sys
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 
 from rich import print
 
@@ -116,10 +117,8 @@ class Log:
 
             if c_size > max_size_kb:
                 old_file = os.path.join(file_path, "gvsbuild-log.old.txt")
-                try:
+                with suppress(FileNotFoundError):
                     os.remove(old_file)
-                except FileNotFoundError:
-                    pass
                 os.rename(self.log_file, old_file)
 
         self.operations = []

--- a/gvsbuild/utils/utils.py
+++ b/gvsbuild/utils/utils.py
@@ -16,6 +16,7 @@
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pathlib
 import re
 import shutil
 import stat
@@ -132,13 +133,8 @@ def python_find_libs_dir(org_dir):
 
     orig_file = os.path.join(chk, "orig-prefix.txt")
     if os.path.isfile(orig_file):
-        # Read and see whats happening
-        with open(orig_file) as fi:
-            org_dir = fi.read()
-
+        # Read and see what's happening
+        org_dir = pathlib.Path(orig_file).read_text()
     # Let's see if now is ok ..
     cur = os.path.join(org_dir, "libs")
-    if os.path.isdir(cur):
-        return cur
-
-    return None
+    return cur if os.path.isdir(cur) else None

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "beautifulsoup4"
@@ -76,7 +76,7 @@ optional = true
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode-backport = ["unicodedata2"]
+unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -91,11 +91,11 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.5"
+version = "0.4.6"
 description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 
 [[package]]
 name = "commonmark"
@@ -118,11 +118,22 @@ python-versions = "*"
 
 [[package]]
 name = "distro"
-version = "1.7.0"
+version = "1.8.0"
 description = "Distro - an OS platform information API"
 category = "main"
 optional = true
 python-versions = ">=3.6"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.0.1"
+description = "Backport of PEP 654 (exception groups)"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "feedparser"
@@ -149,7 +160,7 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pyt
 
 [[package]]
 name = "identify"
-version = "2.5.5"
+version = "2.5.8"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -241,15 +252,15 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "platformdirs"
-version = "2.5.2"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+version = "2.5.3"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
-test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
+test = ["appdirs (==1.4.4)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -311,7 +322,7 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.1.3"
+version = "7.2.0"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
@@ -320,11 +331,11 @@ python-versions = ">=3.7"
 [package.dependencies]
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-py = ">=1.8.2"
-tomli = ">=1.0.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
@@ -364,11 +375,11 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
-version = "12.5.1"
+version = "12.6.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 category = "main"
 optional = false
@@ -384,7 +395,7 @@ jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
 
 [[package]]
 name = "setuptools"
-version = "65.4.1"
+version = "65.5.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
@@ -392,7 +403,7 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -416,7 +427,7 @@ name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
@@ -442,6 +453,28 @@ description = "A lil' TOML parser"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "tox"
+version = "3.27.0"
+description = "tox is a generic virtualenv management and test command line tool"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
+filelock = ">=3.0.0"
+packaging = ">=14"
+pluggy = ">=0.12.0"
+py = ">=1.4.17"
+six = ">=1.14.0"
+tomli = {version = ">=2.0.1", markers = "python_version >= \"3.7\" and python_version < \"3.11\""}
+virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
+
+[package.extras]
+docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)"]
 
 [[package]]
 name = "tqdm"
@@ -482,7 +515,7 @@ test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -503,19 +536,19 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.16.5"
+version = "20.16.6"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-distlib = ">=0.3.5,<1"
+distlib = ">=0.3.6,<1"
 filelock = ">=3.4.1,<4"
 platformdirs = ">=2.4,<3"
 
 [package.extras]
-docs = ["proselint (>=0.13)", "sphinx (>=5.1.1)", "sphinx-argparse (>=0.3.1)", "sphinx-rtd-theme (>=1)", "towncrier (>=21.9)"]
+docs = ["proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-argparse (>=0.3.2)", "sphinx-rtd-theme (>=1)", "towncrier (>=22.8)"]
 testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
 
 [extras]
@@ -524,7 +557,7 @@ outdated = ["lastversion", "packaging"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "73a0ea779f05976f7bbdf18e79192c21f4021f8bc6f7e7d7287a49b12b08185f"
+content-hash = "fb3730cdc8ba37aba9f89a6a65db712f01728412424d1f2ac34a1ee20ab5ac44"
 
 [metadata.files]
 appdirs = [
@@ -560,8 +593,8 @@ click = [
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
-    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
-    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 commonmark = [
     {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
@@ -572,8 +605,12 @@ distlib = [
     {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
 ]
 distro = [
-    {file = "distro-1.7.0-py3-none-any.whl", hash = "sha256:d596311d707e692c2160c37807f83e3820c5d539d5a83e87cfb6babd8ba3a06b"},
-    {file = "distro-1.7.0.tar.gz", hash = "sha256:151aeccf60c216402932b52e40ee477a939f8d58898927378a02abbe852c1c39"},
+    {file = "distro-1.8.0-py3-none-any.whl", hash = "sha256:99522ca3e365cac527b44bde033f64c6945d90eb9f769703caaec52b09bbd3ff"},
+    {file = "distro-1.8.0.tar.gz", hash = "sha256:02e111d1dc6a50abb8eed6bf31c3e48ed8b0830d1ea2a1b78c61765c2513fdd8"},
+]
+exceptiongroup = [
+    {file = "exceptiongroup-1.0.1-py3-none-any.whl", hash = "sha256:4d6c0aa6dd825810941c792f53d7b8d71da26f5e5f84f20f9508e8f2d33b140a"},
+    {file = "exceptiongroup-1.0.1.tar.gz", hash = "sha256:73866f7f842ede6cb1daa42c4af078e2035e5f7607f0e2c762cc51bb31bbe7b2"},
 ]
 feedparser = [
     {file = "feedparser-6.0.10-py3-none-any.whl", hash = "sha256:79c257d526d13b944e965f6095700587f27388e50ea16fd245babe4dfae7024f"},
@@ -584,8 +621,8 @@ filelock = [
     {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
 ]
 identify = [
-    {file = "identify-2.5.5-py2.py3-none-any.whl", hash = "sha256:ef78c0d96098a3b5fe7720be4a97e73f439af7cf088ebf47b620aeaa10fadf97"},
-    {file = "identify-2.5.5.tar.gz", hash = "sha256:322a5699daecf7c6fd60e68852f36f2ecbb6a36ff6e6e973e0d2bb6fca203ee6"},
+    {file = "identify-2.5.8-py2.py3-none-any.whl", hash = "sha256:48b7925fe122720088aeb7a6c34f17b27e706b72c61070f27fe3789094233440"},
+    {file = "identify-2.5.8.tar.gz", hash = "sha256:7a214a10313b9489a0d61467db2856ae8d0b8306fc923e03a9effa53d8aedc58"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -666,8 +703,8 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
-    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+    {file = "platformdirs-2.5.3-py3-none-any.whl", hash = "sha256:0cb405749187a194f444c25c82ef7225232f11564721eabffc6ec70df83b11cb"},
+    {file = "platformdirs-2.5.3.tar.gz", hash = "sha256:6e52c21afff35cb659c6e52d8b4d61b9bd544557180440538f255d9382c8cbe0"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -690,8 +727,8 @@ pyparsing = [
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pytest = [
-    {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
-    {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
+    {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
+    {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -705,13 +742,6 @@ PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
-    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
-    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -744,12 +774,12 @@ requests = [
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
 rich = [
-    {file = "rich-12.5.1-py3-none-any.whl", hash = "sha256:2eb4e6894cde1e017976d2975ac210ef515d7548bc595ba20e195fb9628acdeb"},
-    {file = "rich-12.5.1.tar.gz", hash = "sha256:63a5c5ce3673d3d5fbbf23cd87e11ab84b6b451436f1b7f19ec54b6bc36ed7ca"},
+    {file = "rich-12.6.0-py3-none-any.whl", hash = "sha256:a4eb26484f2c82589bd9a17c73d32a010b1e29d89f1604cd9bf3a2097b81bb5e"},
+    {file = "rich-12.6.0.tar.gz", hash = "sha256:ba3a3775974105c221d31141f2c116f4fd65c5ceb0698657a11e9f295ec93fd0"},
 ]
 setuptools = [
-    {file = "setuptools-65.4.1-py3-none-any.whl", hash = "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012"},
-    {file = "setuptools-65.4.1.tar.gz", hash = "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"},
+    {file = "setuptools-65.5.1-py3-none-any.whl", hash = "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31"},
+    {file = "setuptools-65.5.1.tar.gz", hash = "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"},
 ]
 sgmllib3k = [
     {file = "sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9"},
@@ -774,6 +804,10 @@ tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
+tox = [
+    {file = "tox-3.27.0-py2.py3-none-any.whl", hash = "sha256:89e4bc6df3854e9fc5582462e328dd3660d7d865ba625ae5881bbc63836a6324"},
+    {file = "tox-3.27.0.tar.gz", hash = "sha256:d2c945f02a03d4501374a3d5430877380deb69b218b1df9b7f1d2f2a10befaf9"},
+]
 tqdm = [
     {file = "tqdm-4.64.1-py2.py3-none-any.whl", hash = "sha256:6fee160d6ffcd1b1c68c65f14c829c22832bc401726335ce92c52d395944a6a1"},
     {file = "tqdm-4.64.1.tar.gz", hash = "sha256:5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4"},
@@ -783,14 +817,14 @@ typer = [
     {file = "typer-0.7.0.tar.gz", hash = "sha256:ff797846578a9f2a201b53442aedeb543319466870fbe1c701eab66dd7681165"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
-    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
     {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.16.5-py3-none-any.whl", hash = "sha256:d07dfc5df5e4e0dbc92862350ad87a36ed505b978f6c39609dc489eadd5b0d27"},
-    {file = "virtualenv-20.16.5.tar.gz", hash = "sha256:227ea1b9994fdc5ea31977ba3383ef296d7472ea85be9d6732e42a91c04e80da"},
+    {file = "virtualenv-20.16.6-py3-none-any.whl", hash = "sha256:186ca84254abcbde98180fd17092f9628c5fe742273c02724972a1d8a2035108"},
+    {file = "virtualenv-20.16.6.tar.gz", hash = "sha256:530b850b523c6449406dfba859d6345e48ef19b8439606c5d74d7d3c9e14d76e"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "beautifulsoup4"
@@ -36,7 +36,27 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-name = "CacheControl"
+name = "build"
+version = "0.9.0"
+description = "A simple, correct PEP 517 build frontend"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "os_name == \"nt\""}
+packaging = ">=19.0"
+pep517 = ">=0.9.1"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+docs = ["furo (>=2021.08.31)", "sphinx (>=4.0,<5.0)", "sphinx-argparse-cli (>=1.5)", "sphinx-autodoc-typehints (>=1.10)"]
+test = ["filelock (>=3)", "pytest (>=6.2.4)", "pytest-cov (>=2.12)", "pytest-mock (>=2)", "pytest-rerunfailures (>=9.1)", "pytest-xdist (>=1.34)", "setuptools (>=42.0.0)", "setuptools (>=56.0.0)", "toml (>=0.10.0)", "wheel (>=0.36.0)"]
+typing = ["importlib-metadata (>=4.6.4)", "mypy (==0.950)", "typing-extensions (>=3.7.4.3)"]
+virtualenv = ["virtualenv (>=20.0.35)"]
+
+[[package]]
+name = "cachecontrol"
 version = "0.12.11"
 description = "httplib2 caching for requests"
 category = "main"
@@ -76,7 +96,7 @@ optional = true
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -251,6 +271,17 @@ python-versions = ">=3.6"
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
+name = "pep517"
+version = "0.13.0"
+description = "Wrappers to build Python packages using PEP 517 hooks"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+
+[[package]]
 name = "platformdirs"
 version = "2.5.3"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -299,7 +330,7 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "Pygments"
+name = "pygments"
 version = "2.13.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
@@ -352,7 +383,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
-name = "PyYAML"
+name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
@@ -375,7 +406,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
@@ -450,7 +481,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -557,7 +588,7 @@ outdated = ["lastversion", "packaging"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "fb3730cdc8ba37aba9f89a6a65db712f01728412424d1f2ac34a1ee20ab5ac44"
+content-hash = "9bff375108e7ce0cb5cbbbe1dcf6ba5bd78566f292a42b210809190ddc5109c3"
 
 [metadata.files]
 appdirs = [
@@ -572,7 +603,11 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
     {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
 ]
-CacheControl = [
+build = [
+    {file = "build-0.9.0-py3-none-any.whl", hash = "sha256:38a7a2b7a0bdc61a42a0a67509d88c71ecfc37b393baba770fae34e20929ff69"},
+    {file = "build-0.9.0.tar.gz", hash = "sha256:1a07724e891cbd898923145eb7752ee7653674c511378eb9c7691aab1612bc3c"},
+]
+cachecontrol = [
     {file = "CacheControl-0.12.11-py2.py3-none-any.whl", hash = "sha256:2c75d6a8938cb1933c75c50184549ad42728a27e9f6b92fd677c3151aa72555b"},
     {file = "CacheControl-0.12.11.tar.gz", hash = "sha256:a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144"},
 ]
@@ -702,6 +737,10 @@ packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
+pep517 = [
+    {file = "pep517-0.13.0-py3-none-any.whl", hash = "sha256:4ba4446d80aed5b5eac6509ade100bff3e7943a8489de249654a5ae9b33ee35b"},
+    {file = "pep517-0.13.0.tar.gz", hash = "sha256:ae69927c5c172be1add9203726d4b84cf3ebad1edcd5f71fcdc746e66e829f59"},
+]
 platformdirs = [
     {file = "platformdirs-2.5.3-py3-none-any.whl", hash = "sha256:0cb405749187a194f444c25c82ef7225232f11564721eabffc6ec70df83b11cb"},
     {file = "platformdirs-2.5.3.tar.gz", hash = "sha256:6e52c21afff35cb659c6e52d8b4d61b9bd544557180440538f255d9382c8cbe0"},
@@ -718,7 +757,7 @@ py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
-Pygments = [
+pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
     {file = "Pygments-2.13.0.tar.gz", hash = "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1"},
 ]
@@ -734,7 +773,7 @@ python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
-PyYAML = [
+pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ typer = {extras = ["all"], version = ">=0.6.1,<0.8.0"}
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.18.1"
 pytest = "^7.1.3"
+tox = "^3.27.0"
 
 [tool.poetry.extras]
 outdated = ["lastversion", "packaging"]
@@ -39,3 +40,21 @@ ignore_missing_imports = true
 [tool.isort]
 profile = "black"
 skip = ".venv"
+
+[tool.tox]
+legacy_tox_ini = """
+[tox]
+isolated_build = true
+envlist = py38, py39, py310, py311
+
+[gh-actions]
+python =
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+
+[testenv]
+commands = pytest
+deps = pytest
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
+build = "^0.9.0"
 lastversion = { version = "^2.4.2", optional = true }
 packaging = { version = "^21.3", optional = true }
 typer = {extras = ["all"], version = ">=0.6.1,<0.8.0"}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -51,4 +51,3 @@ def test_platform(tmp_dir, typer_app, runner):
         ],
     )
     assert result.exit_code == 0
-    assert "x86" in result.output

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -47,7 +47,6 @@ def test_platform(tmp_dir, typer_app, runner):
             tmp_dir,
             "--platform",
             "x86",
-            "--same-python",
             "hello-world",
         ],
     )


### PR DESCRIPTION
Currently, gvsbuild downloads versions of Python using nuget, which is unusual for a Python library to do since gvsbuild is being run from an interpreter already. It also requires us to bump supported Python versions every time a point release of Python comes out. This PR removes the `--same-python`, `--python-dir`, and `--python-ver` options and is a breaking change.

Now it always uses the interpreter that gvsbuild was launched with. To ensure that gvsbuild is compatible with all supported Python versions, tox is now used for testing across the versions.

Additionally, this also adds support for Python 3.11 and upgrades poetry to version 1.2.2.