### PR TITLE
Since GTK4 builds are flakey, allow to continue on error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,14 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 75
     if: "!contains(github.event.head_commit.message, 'skip ci')"
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        gtk-version: ['3', '4']
+        gtk-version: ['3']
+        experimental: [false]
+        include:
+          - gtk-version: 4
+            experimental: true
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Sometimes the GTK4 builds work great, other times they get stuck while linking in the GTK build itself.