### PR TITLE
libsoup: patch fixing leak of init message on early termination

### DIFF
--- a/gvsbuild/patches/libsoup/0001-server-connection-fix-dep-cycle-and-connection-leak.patch
+++ b/gvsbuild/patches/libsoup/0001-server-connection-fix-dep-cycle-and-connection-leak.patch
@@ -1,0 +1,30 @@
+From fad02b67ba29e161109db785ea4a2e511439425b Mon Sep 17 00:00:00 2001
+From: BiagioFesta <15035284+BiagioFesta@users.noreply.github.com>
+Date: Wed, 14 Dec 2022 12:20:08 +0100
+Subject: [PATCH] server-connection: fix dep cycle and connection leak
+
+The initial message contains a cycle-reference to the connection. We
+need to decrement the reference in order to properly clean up the
+connection.
+
+Before this patch, it was possible SoupServerConnection-finalize was
+never called. This was causing a memory leak (and socket FD leak).
+---
+ libsoup/server/soup-server-connection.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libsoup/server/soup-server-connection.c b/libsoup/server/soup-server-connection.c
+index ccd8cb57..cac4eaa7 100644
+--- a/libsoup/server/soup-server-connection.c
++++ b/libsoup/server/soup-server-connection.c
+@@ -98,6 +98,7 @@ disconnect_internal (SoupServerConnection *conn)
+         g_io_stream_close (priv->conn, NULL, NULL);
+         g_signal_handlers_disconnect_by_data (priv->conn, conn);
+         g_clear_object (&priv->conn);
++        g_clear_object (&priv->initial_msg);
+ 
+         g_clear_pointer (&priv->io_data, soup_server_message_io_destroy);
+ }
+-- 
+2.39.0
+

--- a/gvsbuild/projects/libsoup.py
+++ b/gvsbuild/projects/libsoup.py
@@ -77,6 +77,7 @@ class Libsoup3(Tarball, Meson):
                 "mit-kerberos",
                 "nghttp2",
             ],
+            patches=["0001-server-connection-fix-dep-cycle-and-connection-leak.patch"],
         )
 
         if self.opts.enable_gi:


### PR DESCRIPTION
The same patch has been approved and merged upstream: https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/339

This does not affect version 2