### PR TITLE
Fix UnicodeDecodeError when checking Msvc tool

### DIFF
--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -319,8 +319,8 @@ class Builder:
 
         completed_process = subprocess.run(
             [f"{vswhere}", "-all", "-products", "*", "-format", "json", "-utf8"],
-            text=True,
             capture_output=True,
+            encoding='utf-8',
         )
         try:
             completed_process.check_returncode()

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -320,7 +320,7 @@ class Builder:
         completed_process = subprocess.run(
             [f"{vswhere}", "-all", "-products", "*", "-format", "json", "-utf8"],
             capture_output=True,
-            encoding='utf-8',
+            encoding="utf-8",
         )
         try:
             completed_process.check_returncode()


### PR DESCRIPTION
According to Python 3 documentation https://docs.python.org/3/library/subprocess.html:
If encoding or errors are specified, or text is true, file objects for stdin, stdout and stderr are opened in text mode using the specified encoding and errors or the io.TextIOWrapper default.

Close #778 