### PR TITLE
Fix Out of Memory Error When Setting Fonts in Cairo

### DIFF
--- a/gvsbuild/patches/cairo/0001-dwrite-toy-fonts.patch
+++ b/gvsbuild/patches/cairo/0001-dwrite-toy-fonts.patch
@@ -1,0 +1,30 @@
+From 36d75971dde8dffd80311b0e67de53b5dd919e3b Mon Sep 17 00:00:00 2001
+From: Adrian Johnson <ajohnson@redneon.com>
+Date: Sun, 20 Mar 2022 11:15:12 +1030
+Subject: [PATCH] Ensure DWrite toy fonts can not fail if font name not found
+
+---
+ src/win32/cairo-dwrite-font.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/win32/cairo-dwrite-font.cpp b/src/win32/cairo-dwrite-font.cpp
+index afa859fbd..575d46642 100644
+--- a/src/win32/cairo-dwrite-font.cpp
++++ b/src/win32/cairo-dwrite-font.cpp
+@@ -327,8 +327,12 @@ _cairo_dwrite_font_face_create_for_toy (cairo_toy_font_face_t   *toy_face,
+     IDWriteFontFamily *family = DWriteFactory::FindSystemFontFamily(face_name);
+     delete face_name;
+     if (!family) {
+-	*font_face = (cairo_font_face_t*)&_cairo_font_face_nil;
+-	return CAIRO_STATUS_FONT_TYPE_MISMATCH;
++	/* If the family is not found, pick a default that should work to avoid failing. */
++	family = DWriteFactory::FindSystemFontFamily(L"Arial");
++	if (!family) {
++	    *font_face = (cairo_font_face_t*)&_cairo_font_face_nil;
++	    return CAIRO_STATUS_FONT_TYPE_MISMATCH;
++	}
+     }
+
+     DWRITE_FONT_WEIGHT weight;
+--
+GitLab

--- a/gvsbuild/patches/cairo/0002-fix-scaled-font-hash-lookup.patch
+++ b/gvsbuild/patches/cairo/0002-fix-scaled-font-hash-lookup.patch
@@ -1,0 +1,36 @@
+From 90938531a9fe0fef1873c790d648bd0410cdf72e Mon Sep 17 00:00:00 2001
+From: Luca Bacci <luca.bacci982@gmail.com>
+Date: Sat, 3 Sep 2022 17:29:51 +0200
+Subject: [PATCH] Fix scaled_glyph hash lookup on Win64
+
+Backport of https://gitlab.freedesktop.org/cairo/cairo/-/commit/1cc23206bde186d4aef948bba11e591120c99dcd
+to 1.17.6
+---
+ src/cairo-scaled-font.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/cairo-scaled-font.c b/src/cairo-scaled-font.c
+index e0b586589..30611dca4 100755
+--- a/src/cairo-scaled-font.c
++++ b/src/cairo-scaled-font.c
+@@ -3001,6 +3001,7 @@ _cairo_scaled_glyph_lookup (cairo_scaled_font_t *scaled_font,
+     cairo_int_status_t		 status = CAIRO_INT_STATUS_SUCCESS;
+     cairo_scaled_glyph_t	*scaled_glyph;
+     cairo_scaled_glyph_info_t	 need_info;
++    cairo_hash_entry_t           key;
+
+     *scaled_glyph_ret = NULL;
+
+@@ -3019,8 +3020,8 @@ _cairo_scaled_glyph_lookup (cairo_scaled_font_t *scaled_font,
+     /*
+      * Check cache for glyph
+      */
+-    scaled_glyph = _cairo_hash_table_lookup (scaled_font->glyphs,
+-					     (cairo_hash_entry_t *) &index);
++    key.hash = index;
++    scaled_glyph = _cairo_hash_table_lookup (scaled_font->glyphs, &key);
+     if (scaled_glyph == NULL) {
+ 	status = _cairo_scaled_font_allocate_glyph (scaled_font, &scaled_glyph);
+ 	if (unlikely (status))
+--
+2.36.1.windows.1

--- a/gvsbuild/projects/cairo.py
+++ b/gvsbuild/projects/cairo.py
@@ -30,7 +30,10 @@ class Cairo(Tarball, Meson):
             archive_url="https://gitlab.freedesktop.org/cairo/cairo/-/archive/{version}/cairo-{version}.tar.gz",
             hash="a2227afc15e616657341c42af9830c937c3a6bfa63661074eabef13600e8936f",
             dependencies=["fontconfig", "freetype", "glib", "pixman", "libpng"],
-            patches=[],
+            patches=[
+                "0001-dwrite-toy-fonts.patch",
+                "0002-fix-scaled-font-hash-lookup.patch",
+            ],
         )
 
     def build(self):


### PR DESCRIPTION
I was getting test failures with pycairo:

```
    def test_toy_font_get_family():
        font_face = cairo.ToyFontFace("")
        assert isinstance(font_face.get_family(), str)
>       font_face = cairo.ToyFontFace("sans-serif")
E       tests.test_font.cairo.MemoryError: out of memory
```

This PR adds a patch to fix this font setting issue and also a patch to fix a scaled_hash lookup error in Windows.