### PR TITLE
Change zlib archive url to fix CI flakiness

### DIFF
--- a/gvsbuild/projects/zlib.py
+++ b/gvsbuild/projects/zlib.py
@@ -39,8 +39,8 @@ class Zlib(Tarball, Project):
             self,
             "zlib",
             version="1.2.13",
-            archive_url="http://www.zlib.net/fossils/zlib-{version}.tar.gz",
-            hash="b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
+            archive_url="https://github.com/madler/zlib/releases/download/v{version}/zlib-{version}.tar.xz",
+            hash="d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98",
         )
 
     def build(self):


### PR DESCRIPTION
Downloading from zlib.net has been causing quite a few build failures, this PR updates the URL to the GitHub project.