### PR TITLE
Update gstreamer and libvpx

### DIFF
--- a/gvsbuild/patches/libvpx/0001-Always-generate-pc-file.patch
+++ b/gvsbuild/patches/libvpx/0001-Always-generate-pc-file.patch
@@ -2,25 +2,19 @@ From d1953749eb6876ef88a57e004b06f33b68d42664 Mon Sep 17 00:00:00 2001
 From: Ignacio Casal Quinteiro <qignacio@amazon.com>
 Date: Mon, 26 Oct 2020 16:07:34 +0100
 Subject: [PATCH] Always generate pc file
-
----
- libs.mk | 39 +++++++++++++++++++--------------------
- 1 file changed, 19 insertions(+), 20 deletions(-)
-
+===================================================================
 diff --git a/libs.mk b/libs.mk
-index d14439a3d..5f44594ff 100644
---- a/libs.mk
-+++ b/libs.mk
-@@ -358,6 +358,22 @@ INSTALL-LIBS-$(CONFIG_SHARED) += $(LIBVPX_SO_SYMLINKS)
+--- a/libs.mk	(revision 11151943b1877824da6086ea0c89b5617caecb67)
++++ b/libs.mk	(date 1671827127830)
+@@ -385,6 +385,21 @@
  INSTALL-LIBS-$(CONFIG_SHARED) += $(LIBSUBDIR)/$(LIBVPX_SO)
  INSTALL-LIBS-$(CONFIG_SHARED) += $(if $(LIBVPX_SO_IMPLIB),$(LIBSUBDIR)/$(LIBVPX_SO_IMPLIB))
  
-+ifeq ($(CONFIG_VP9_ENCODER),yes)
-+  RC_RTC_OBJS=$(call objs,$(RC_RTC_SRCS))
++ifeq ($(CONFIG_ENCODERS),yes)
 +  RC_RTC_OBJS=$(call objs,$(RC_RTC_SRCS))
 +  OBJS-yes += $(RC_RTC_OBJS)
-+  LIBS-yes += $(BUILD_PFX)libvp9rc.a $(BUILD_PFX)libvp9rc_g.a
-+  $(BUILD_PFX)libvp9rc_g.a: $(RC_RTC_OBJS)
++  LIBS-yes += $(BUILD_PFX)libvpxrc.a $(BUILD_PFX)libvpxrc_g.a
++  $(BUILD_PFX)libvpxrc_g.a: $(RC_RTC_OBJS)
 +endif
 +
 +ifeq ($(CONFIG_VP9_ENCODER)$(CONFIG_RATE_CTRL),yesyes)
@@ -34,7 +28,7 @@ index d14439a3d..5f44594ff 100644
  
  LIBS-yes += vpx.pc
  vpx.pc: config.mk libs.mk
-@@ -373,34 +389,17 @@ vpx.pc: config.mk libs.mk
+@@ -400,33 +415,17 @@
  	$(qexec)echo 'Version: $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)' >> $@
  	$(qexec)echo 'Requires:' >> $@
  	$(qexec)echo 'Conflicts:' >> $@
@@ -42,7 +36,7 @@ index d14439a3d..5f44594ff 100644
 +	$(qexec)echo 'Libs: -L$${libdir} -lvpx' >> $@
  ifeq ($(HAVE_PTHREAD_H),yes)
 -	$(qexec)echo 'Libs.private: -lm -lpthread' >> $@
-+	$(qexec)echo 'Libs.private: -pthread' >> $@
++	$(qexec)echo 'Libs.private: -lpthread' >> $@
  else
 -	$(qexec)echo 'Libs.private: -lm' >> $@
 +	$(qexec)echo 'Libs.private: ' >> $@
@@ -52,12 +46,11 @@ index d14439a3d..5f44594ff 100644
  INSTALL_MAPS += $(LIBSUBDIR)/pkgconfig/%.pc %.pc
  CLEAN-OBJS += vpx.pc
  
--ifeq ($(CONFIG_VP9_ENCODER),yes)
--  RC_RTC_OBJS=$(call objs,$(RC_RTC_SRCS))
+-ifeq ($(CONFIG_ENCODERS),yes)
 -  RC_RTC_OBJS=$(call objs,$(RC_RTC_SRCS))
 -  OBJS-yes += $(RC_RTC_OBJS)
--  LIBS-yes += $(BUILD_PFX)libvp9rc.a $(BUILD_PFX)libvp9rc_g.a
--  $(BUILD_PFX)libvp9rc_g.a: $(RC_RTC_OBJS)
+-  LIBS-yes += $(BUILD_PFX)libvpxrc.a $(BUILD_PFX)libvpxrc_g.a
+-  $(BUILD_PFX)libvpxrc_g.a: $(RC_RTC_OBJS)
 -endif
 -
 -ifeq ($(CONFIG_VP9_ENCODER)$(CONFIG_RATE_CTRL),yesyes)
@@ -72,6 +65,3 @@ index d14439a3d..5f44594ff 100644
  libvpx.ver: $(call enabled,CODEC_EXPORTS)
  	@echo "    [CREATE] $@"
  	$(qexec)echo "{ global:" > $@
--- 
-2.17.1
-

--- a/gvsbuild/projects/gstreamer.py
+++ b/gvsbuild/projects/gstreamer.py
@@ -96,6 +96,13 @@ class GstPluginsBase(Tarball, Meson):
             hash="11f911ef65f3095d7cf698a1ad1fc5242ac3ad6c9270465fb5c9e7f4f9c19b35",
             dependencies=["meson", "ninja", "gtk3", "gstreamer", "opus"],
         )
+        if self.opts.enable_gi:
+            self.add_dependency("gobject-introspection")
+            enable_gi = "enabled"
+        else:
+            enable_gi = "disabled"
+
+        self.add_param(f"-Dintrospection={enable_gi}")
 
     def build(self):
         Meson.build(self)

--- a/gvsbuild/projects/gstreamer.py
+++ b/gvsbuild/projects/gstreamer.py
@@ -41,9 +41,9 @@ class GStreamer(Tarball, Meson):
         Project.__init__(
             self,
             "gstreamer",
-            version="1.20.4",
+            version="1.20.5",
             archive_url="https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-{version}.tar.xz",
-            hash="67c1edf8c3c339cda5dde85f4f7b953bb9607c2d13ae970e2491c5c4c055ef5f",
+            hash="5a19083faaf361d21fc391124f78ba6d609be55845a82fa8f658230e5fa03dff",
             dependencies=["meson", "ninja", "glib", "orc"],
         )
 
@@ -91,9 +91,9 @@ class GstPluginsBase(Tarball, Meson):
         Project.__init__(
             self,
             "gst-plugins-base",
-            version="1.20.4",
+            version="1.20.5",
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-{version}.tar.xz",
-            hash="8d181b7abe4caf23ee9f9ec5b4d3e232640452464e39495bfffb6d776fc97225",
+            hash="11f911ef65f3095d7cf698a1ad1fc5242ac3ad6c9270465fb5c9e7f4f9c19b35",
             dependencies=["meson", "ninja", "gtk3", "gstreamer", "opus"],
         )
 
@@ -108,9 +108,9 @@ class GstPluginsGood(Tarball, Meson):
         Project.__init__(
             self,
             "gst-plugins-good",
-            version="1.20.4",
+            version="1.20.5",
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-{version}.tar.xz",
-            hash="b16130fbe632fa8547c2147a0ef575b0140fb521065c5cb121c72ddbd23b64da",
+            hash="e83ab4d12ca24959489bbb0ec4fac9b90e32f741d49cda357cb554b2cb8b97f9",
             dependencies=[
                 "meson",
                 "ninja",
@@ -132,9 +132,9 @@ class GstPluginsBad(Tarball, Meson):
         Project.__init__(
             self,
             "gst-plugins-bad",
-            version="1.20.4",
+            version="1.20.5",
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-{version}.tar.xz",
-            hash="a1a3f53b3604d9a04fdd0bf9a1a616c3d2dab5320489e9ecee1178e81e33a16a",
+            hash="f431214b0754d7037adcde93c3195106196588973e5b32dcb24938805f866363",
             dependencies=["meson", "ninja", "glib", "gstreamer", "gst-plugins-base"],
             patches=[
                 "wasapisink-reduce-buffer-latency.patch",
@@ -154,9 +154,9 @@ class GstPython(Tarball, Meson):
         Project.__init__(
             self,
             "gst-python",
-            version="1.20.4",
+            version="1.20.5",
             archive_url="https://gstreamer.freedesktop.org/src/gst-python/gst-python-{version}.tar.xz",
-            hash="5eb4136d03e2a495f4499c8b2e6d9d3e7b5e73c5a8b8acf9213d57bc6a7bd3c1",
+            hash="27487652318659cfd7dc42784b713c78d29cc7a7df4fb397134c8c125f65e3b2",
             dependencies=["meson", "ninja", "glib", "gstreamer", "pygobject"],
         )
 

--- a/gvsbuild/projects/libvpx.py
+++ b/gvsbuild/projects/libvpx.py
@@ -28,9 +28,10 @@ class Libvpx(Tarball, Project):
         Project.__init__(
             self,
             "libvpx",
-            version="1.10.0",
+            version="1.12.0",
             archive_url="https://github.com/webmproject/libvpx/archive/v{version}.tar.gz",
-            hash="85803ccbdbdd7a3b03d930187cb055f1353596969c1f92ebec2db839fa4f834a",
+            archive_file_name="libvpx-v{version}.tar.gz",
+            hash="f1acc15d0fd0cb431f4bf6eac32d5e932e40ea1186fe78e074254d6d003957bb",
             dependencies=["yasm", "msys2", "libyuv", "perl"],
             patches=[
                 "0006-gen_msvs_vcxproj.sh-Select-current-Windows-SDK-if-av.patch",

--- a/gvsbuild/projects/pycairo.py
+++ b/gvsbuild/projects/pycairo.py
@@ -17,14 +17,15 @@
 
 from pathlib import Path
 
+from gvsbuild.utils.base_builders import Meson
 from gvsbuild.utils.base_expanders import Tarball
-from gvsbuild.utils.base_project import Project, project_add
+from gvsbuild.utils.base_project import project_add
 
 
 @project_add
-class Pycairo(Tarball, Project):
+class Pycairo(Tarball, Meson):
     def __init__(self):
-        Project.__init__(
+        Meson.__init__(
             self,
             "pycairo",
             version="1.23.0",
@@ -34,6 +35,7 @@ class Pycairo(Tarball, Project):
         )
 
     def build(self):
+        Meson.build(self)
         cairo_inc = Path(self.builder.gtk_dir) / "include" / "cairo"
         self.builder.mod_env("INCLUDE", str(cairo_inc))
         self.exec_vs(r"%(python_dir)s\python.exe -m build")

--- a/gvsbuild/projects/pygobject.py
+++ b/gvsbuild/projects/pygobject.py
@@ -17,12 +17,13 @@
 
 from pathlib import Path
 
+from gvsbuild.utils.base_builders import Meson
 from gvsbuild.utils.base_expanders import Tarball
 from gvsbuild.utils.base_project import Project, project_add
 
 
 @project_add
-class PyGObject(Tarball, Project):
+class PyGObject(Tarball, Meson):
     def __init__(self):
         Project.__init__(
             self,
@@ -38,6 +39,7 @@ class PyGObject(Tarball, Project):
         )
 
     def build(self):
+        Meson.build(self)
         gtk_dir = self.builder.gtk_dir
         add_inc = [
             str(Path(gtk_dir) / "include" / "cairo"),


### PR DESCRIPTION
This PR:

- Updates gstreamer and plugins to version 1.20.5
- Enables introspection for gst-plugins-base which closes #670 
- libvpx to version 1.12.0 which allows building with VS17
- Build pygobject and pycairo with meson so that gst-python can build against pygobject