### PR TITLE
Add additional repos for outdated parsing

### DIFF
--- a/gvsbuild/projects/clutter.py
+++ b/gvsbuild/projects/clutter.py
@@ -25,7 +25,7 @@ class Clutter(Tarball, Project):
         Project.__init__(
             self,
             "clutter",
-            repository="https://gitlab.gnome.org/GNOME/clutter",
+            repository="https://gitlab.gnome.org/Archive/clutter",
             version="1.26.4",
             archive_url="https://download.gnome.org/sources/clutter/{major}.{minor}/clutter-{version}.tar.xz",
             hash="8b48fac159843f556d0a6be3dbfc6b083fc6d9c58a20a49a6b4919ab4263c4e6",

--- a/gvsbuild/projects/gstreamer.py
+++ b/gvsbuild/projects/gstreamer.py
@@ -41,6 +41,7 @@ class GStreamer(Tarball, Meson):
         Project.__init__(
             self,
             "gstreamer",
+            repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
             version="1.20.5",
             archive_url="https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-{version}.tar.xz",
             hash="5a19083faaf361d21fc391124f78ba6d609be55845a82fa8f658230e5fa03dff",
@@ -91,6 +92,7 @@ class GstPluginsBase(Tarball, Meson):
         Project.__init__(
             self,
             "gst-plugins-base",
+            repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
             version="1.20.5",
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-{version}.tar.xz",
             hash="11f911ef65f3095d7cf698a1ad1fc5242ac3ad6c9270465fb5c9e7f4f9c19b35",
@@ -118,6 +120,7 @@ class GstPluginsGood(Tarball, Meson):
         Project.__init__(
             self,
             "gst-plugins-good",
+            repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
             version="1.20.5",
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-{version}.tar.xz",
             hash="e83ab4d12ca24959489bbb0ec4fac9b90e32f741d49cda357cb554b2cb8b97f9",
@@ -142,6 +145,7 @@ class GstPluginsBad(Tarball, Meson):
         Project.__init__(
             self,
             "gst-plugins-bad",
+            repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
             version="1.20.5",
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-{version}.tar.xz",
             hash="f431214b0754d7037adcde93c3195106196588973e5b32dcb24938805f866363",
@@ -164,6 +168,7 @@ class GstPython(Tarball, Meson):
         Project.__init__(
             self,
             "gst-python",
+            repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
             version="1.20.5",
             archive_url="https://gstreamer.freedesktop.org/src/gst-python/gst-python-{version}.tar.xz",
             hash="27487652318659cfd7dc42784b713c78d29cc7a7df4fb397134c8c125f65e3b2",

--- a/gvsbuild/projects/icu.py
+++ b/gvsbuild/projects/icu.py
@@ -27,6 +27,7 @@ class Icu(Tarball, Project):
         Project.__init__(
             self,
             "icu",
+            repository="https://github.com/unicode-org/icu",
             version="72.1",
             archive_url="https://github.com/unicode-org/icu/releases/download/release-{major}-{minor}/icu4c-{major}_{minor}-src.zip",
             hash="13ad093c113d841ca2072ebc4488c2d235d2e0196d0d7a730745a25a3d070fe4",

--- a/gvsbuild/projects/libadwaita.py
+++ b/gvsbuild/projects/libadwaita.py
@@ -27,6 +27,7 @@ class Libadwaita(Tarball, Meson):
         Project.__init__(
             self,
             "libadwaita",
+            repository="https://gitlab.gnome.org/GNOME/libadwaita",
             version="1.2.0",
             archive_url="https://download.gnome.org/sources/libadwaita/{major}.{minor}/libadwaita-{version}.tar.xz",
             hash="322f3e1be39ba67981d9fe7228a85818eccaa2ed0aa42bcafe263af881c6460c",

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -129,6 +129,7 @@ class ToolMeson(Tool):
 class ToolMsys2(Tool):
     def __init__(self):
         Tool.__init__(self, "msys2")
+        self.internal = True
 
     def load_defaults(self):
         Tool.load_defaults(self)


### PR DESCRIPTION
Improves parsing by the outdated command so that it can find the right versions for gstreamer and gst plugins, clutter, ICU, and libadwaita. It also hides msys2 from the outdated list because it is installed externally to gvsbuild.