### PR TITLE
Fix PEP597 Encoding Warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,9 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-eradicate==1.2.0]
+        additional_dependencies:
+        - flake8-eradicate==1.2.0
+        - flake8-encodings==0.5.0.post1
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/gvsbuild/deps.py
+++ b/gvsbuild/deps.py
@@ -129,7 +129,7 @@ def make_graph(
     gr_index = 0
 
     to_skip = set(skip)
-    with open(out_file, "wt") as fo:
+    with open(out_file, "wt", encoding="utf-8") as fo:
         print(f"Writing file {out_file}")
         used = set()
         fo.write("digraph gtk3dep {\n")

--- a/gvsbuild/deps.py
+++ b/gvsbuild/deps.py
@@ -151,31 +151,15 @@ def make_graph(
                         gr_index %= len(gr_colors)
                         for d in t.dependencies:
                             if d in to_skip:
-                                print(
-                                    "Skip '%s' for '%s'"
-                                    % (
-                                        d,
-                                        n,
-                                    )
-                                )
+                                print(f"Skip '{d}' for '{n}'")
                             else:
                                 if invert_dep:
                                     fo.write(
-                                        '    "%s" -> "%s" [color="#%06x"];\n'
-                                        % (
-                                            d,
-                                            n,
-                                            gr_colors[gr_index],
-                                        )
+                                        f'    "{d}" -> "{n}" [color="#{gr_colors[gr_index]:06x}"];\n'
                                     )
                                 else:
                                     fo.write(
-                                        '    "%s" -> "%s" [color="#%06x"];\n'
-                                        % (
-                                            n,
-                                            d,
-                                            gr_colors[gr_index],
-                                        )
+                                        f'    "{n}" -> "{d}" [color="#{gr_colors[gr_index]:06x}"];\n'
                                     )
                                 used.add(d)
                 else:
@@ -185,13 +169,7 @@ def make_graph(
             # Puts all projects that are not referenced from others
             for n in Project._names:
                 if n not in used:
-                    fo.write(
-                        '    "%s" -> "%s" [color="#c00080"];\n'
-                        % (
-                            "BUILD",
-                            n,
-                        )
-                    )
+                    fo.write(f'    "BUILD" -> "{n}" [color="#c00080"];\n')
 
         fo.write("};\n")
 

--- a/gvsbuild/projects/openssl.py
+++ b/gvsbuild/projects/openssl.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
+
 from gvsbuild.utils.base_expanders import Tarball
 from gvsbuild.utils.base_project import Project, project_add
 
@@ -61,11 +63,8 @@ class OpenSSL(Tarball, Project):
                 + common_options
             )
 
-        try:
+        with contextlib.suppress(Exception):
             self.exec_vs(r"nmake /nologo clean", add_path=add_path)
-        except:  # noqa E722
-            pass
-
         self.exec_vs(r"nmake /nologo", add_path=add_path)
         self.exec_vs(r"%(perl_dir)s\bin\perl.exe mk-ca-bundle.pl -n cert.pem")
         self.exec_vs(r"nmake /nologo install", add_path=add_path)

--- a/gvsbuild/projects/pixman.py
+++ b/gvsbuild/projects/pixman.py
@@ -41,7 +41,7 @@ class Pixman(Tarball, Project):
         add_path = os.path.join(self.builder.opts.msys_dir, "usr", "bin")
 
         self.exec_vs(
-            r"make -f Makefile.win32 pixman CFG=%(configuration)s " + optimizations,
+            f"make -f Makefile.win32 pixman CFG=%(configuration)s {optimizations}",
             add_path=add_path,
         )
 

--- a/gvsbuild/utils/base_builders.py
+++ b/gvsbuild/utils/base_builders.py
@@ -94,18 +94,13 @@ class CmakeProject(Project):
         out_of_source=None,
         source_part=None,
     ):
+        cmake_gen = "Ninja" if use_ninja else "NMake Makefiles"
+
         cmake_config = (
             "Debug" if self.builder.opts.configuration == "debug" else "RelWithDebInfo"
         )
-        cmake_gen = "Ninja" if use_ninja else "NMake Makefiles"
-
         # Create the command for cmake
-        cmd = (
-            'cmake -G "'
-            + cmake_gen
-            + '" -DCMAKE_INSTALL_PREFIX="%(pkg_dir)s" -DGTK_DIR="%(gtk_dir)s" -DCMAKE_BUILD_TYPE='
-            + cmake_config
-        )
+        cmd = f'cmake -G "{cmake_gen}" -DCMAKE_INSTALL_PREFIX="%(pkg_dir)s" -DGTK_DIR="%(gtk_dir)s" -DCMAKE_BUILD_TYPE={cmake_config}'
         if cmake_params:
             cmd += f" {cmake_params}"
         if use_ninja and out_of_source is None:

--- a/gvsbuild/utils/base_expanders.py
+++ b/gvsbuild/utils/base_expanders.py
@@ -31,7 +31,7 @@ def read_mark_file(directory, file_name=".wingtk-extracted-file"):
     """Read a single line from file, returning an empty string on error."""
     rt = ""
     try:
-        with open(os.path.join(directory, file_name)) as fi:
+        with open(os.path.join(directory, file_name), encoding="utf-8") as fi:
             rt = fi.readline().strip()
     except OSError as e:
         log.debug(f"Exception on reading from '{file_name}'")
@@ -42,7 +42,7 @@ def read_mark_file(directory, file_name=".wingtk-extracted-file"):
 
 def write_mark_file(directory, val, file_name=".wingtk-extracted-file"):
     """Write the value (filename or content hash) to the mark file."""
-    with open(os.path.join(directory, file_name), "wt") as fo:
+    with open(os.path.join(directory, file_name), "wt", encoding="utf-8") as fo:
         fo.write(f"{val}\n")
 
 
@@ -274,7 +274,7 @@ class GitRepo:
             self.builder.exec_msys(
                 f"git rev-parse --short HEAD >{of}", working_dir=src_dir
             )
-            with open(of) as fi:
+            with open(of, encoding="utf-8") as fi:
                 tag_name = fi.readline().rstrip("\n")
             os.remove(of)
 

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -425,7 +425,9 @@ class Project(Generic[P]):
                 _t = content.replace("@version@", self.version)
                 content = _t
 
-                with open(os.path.join(pkgconfig_dir, f.name), "wt") as fo:
+                with open(
+                    os.path.join(pkgconfig_dir, f.name), "wt", encoding="utf-8"
+                ) as fo:
                     fo.write(content)
 
     def patch(self):
@@ -437,7 +439,7 @@ class Project(Generic[P]):
                 self.builder.exec_msys(
                     ["patch", "-p1", "-i", p], working_dir=self._get_working_dir()
                 )
-                with open(stamp, "w") as stampfile:
+                with open(stamp, "w", encoding="utf-8") as stampfile:
                     stampfile.write("done")
             else:
                 log.debug(f"patch {p} already applied, skipping")
@@ -580,7 +582,7 @@ class Project(Generic[P]):
     def mark_file_write(self):
         self.mark_file_calc()
         try:
-            with open(self.mark_file, "wt") as fo:
+            with open(self.mark_file, "wt", encoding="utf-8") as fo:
                 now = datetime.datetime.now().replace(microsecond=0)
                 fo.write(f"{now.strftime('%Y-%m-%d %H:%M:%S')}\n")
         except FileNotFoundError as e:
@@ -591,7 +593,7 @@ class Project(Generic[P]):
         self.mark_file_calc()
         if os.path.isfile(self.mark_file):
             try:
-                with open(self.mark_file) as fi:
+                with open(self.mark_file, encoding="utf-8") as fi:
                     rt = fi.readline().strip("\n")
             except OSError as e:
                 print(f"Exception reading file '{self.mark_file}'")

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -375,11 +375,7 @@ class Builder:
                 % (vcvars_bat, vs_path, opts.platform)
             )
         return subprocess.check_output(
-            'cmd.exe /c ""%s"%s>NUL && set"'
-            % (
-                vcvars_bat,
-                add_opts,
-            ),
+            f'cmd.exe /c ""{vcvars_bat}"{add_opts}>NUL && set"',
             encoding="utf-8",
             shell=True,
             text=True,

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -380,6 +380,7 @@ class Builder:
                 vcvars_bat,
                 add_opts,
             ),
+            encoding="utf-8",
             shell=True,
             text=True,
         )

--- a/gvsbuild/utils/utils.py
+++ b/gvsbuild/utils/utils.py
@@ -29,8 +29,7 @@ def convert_to_msys(path):
     path = path
     if path[1] != ":":
         raise NotADirectoryError("Path doesn't contain a drive letter like C:")
-    path = f"/{path[0]}" + path[2:].replace("\\", "/")
-    return path
+    return f"/{path[0]}" + path[2:].replace("\\", "/")
 
 
 def _rmtree_error_handler(func, path, exc_info):

--- a/gvsbuild/utils/utils.py
+++ b/gvsbuild/utils/utils.py
@@ -57,13 +57,13 @@ def rmtree_full(dest_dir, retry=False):
 
 
 def read_file(file_name):
-    with open(file_name) as fi:
+    with open(file_name, encoding="utf-8") as fi:
         rt = [line.rstrip("\n") for line in fi]
     return rt
 
 
 def write_file(file_name, content):
-    with open(file_name, "wt") as fo:
+    with open(file_name, "wt", encoding="utf-8") as fo:
         for i in content:
             fo.write(f"{i}\n")
 


### PR DESCRIPTION
PEP 597 adds encoding warnings and will eventually make UTF-8 the default encoding in Python. This PR fixes encoding warnings to help prevent bugs due to encoding warnings. It also adds a pre-commit flake8 hook to help ensure new encoding warnings aren't introduced.

I also noticed that on the Files changed diff in GitHub that it shows utils.py as completely changed. I am not sure why that is, maybe line endings? The file shows CRLF locally while open which is right.

I also did some extra refactoring, including converting some remaining strings to f-strings to leave the code better than I found it 😉 