### PR TITLE
Fix libffi commit reference missing

### DIFF
--- a/gvsbuild/projects/libffi.py
+++ b/gvsbuild/projects/libffi.py
@@ -26,7 +26,7 @@ class Libffi(GitRepo, Meson):
         Project.__init__(
             self,
             "libffi",
-            repo_url="https://github.com/xclaesse/libffi.git",
+            repo_url="https://github.com/wingtk/libffi.git",
             fetch_submodules=False,
             tag="27470bd6b428fe598b39f19610200fb0e975ce5d",
             dependencies=["ninja", "meson"],

--- a/gvsbuild/projects/libffi.py
+++ b/gvsbuild/projects/libffi.py
@@ -28,7 +28,7 @@ class Libffi(GitRepo, Meson):
             "libffi",
             repo_url="https://github.com/xclaesse/libffi.git",
             fetch_submodules=False,
-            tag="e610a433b1323a4d0658dda5e0fd627f8364669a",
+            tag="27470bd6b428fe598b39f19610200fb0e975ce5d",
             dependencies=["ninja", "meson"],
         )
 


### PR DESCRIPTION
Fixes #811. We'll want to create a new release once this is merged since this issue was breaking the GTK build.