### PR TITLE
Fix protobuf version detection

### DIFF
--- a/gvsbuild/projects/protobuf.py
+++ b/gvsbuild/projects/protobuf.py
@@ -27,6 +27,7 @@ class Protobuf(Tarball, CmakeProject):
             self,
             "protobuf",
             version="3.21.12",
+            lastversion_major=3,
             archive_url="https://github.com/protocolbuffers/protobuf/releases/download/v{minor}.{micro}/protobuf-cpp-{version}.tar.gz",
             hash="4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c607f73460",
             dependencies=[


### PR DESCRIPTION
The main project version is 21.10, and then the protobuf-c version is 3.21.10. This PR updates the version detection to look at the main project version.