### PR TITLE
Split "release" from "debug-optimized" configuration

### DIFF
--- a/gvsbuild/utils/base_builders.py
+++ b/gvsbuild/utils/base_builders.py
@@ -64,9 +64,10 @@ class Meson(Project):
         self._ensure_params()
         add_opts = " ".join(self.params) + " " if self.params else ""
         # debug info
-        add_opts += "--buildtype " + (
-            "debug" if self.builder.opts.configuration == "debug" else "debugoptimized"
-        )
+        build_type = self.builder.opts.configuration
+        if self.builder.opts.release_configuration_is_actually_debug_optimized:
+            build_type = "debugoptimized"
+        add_opts += "--buildtype " + build_type
         if meson_params:
             add_opts += f" {meson_params}"
         # python meson.py src_dir ninja_build_dir --prefix gtk_bin options
@@ -97,8 +98,10 @@ class CmakeProject(Project):
         cmake_gen = "Ninja" if use_ninja else "NMake Makefiles"
 
         cmake_config = (
-            "Debug" if self.builder.opts.configuration == "debug" else "RelWithDebInfo"
+            "Debug" if self.builder.opts.configuration == "debug" else "Release"
         )
+        if self.builder.opts.release_configuration_is_actually_debug_optimized:
+            cmake_config = "RelWithDebInfo"
         # Create the command for cmake
         cmd = f'cmake -G "{cmake_gen}" -DCMAKE_INSTALL_PREFIX="%(pkg_dir)s" -DGTK_DIR="%(gtk_dir)s" -DCMAKE_BUILD_TYPE={cmake_config}'
         if cmake_params:

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -45,6 +45,7 @@ class Options:
         self.debug = False
         self.platform = "x64"
         self.configuration = "release"
+        self.release_configuration_is_actually_debug_optimized = False
         self.build_dir = None
         self.archives_download_dir = None
         self.export_dir = None


### PR DESCRIPTION
Some downstream projects may want to avoid the size cost of including debug symbols in packaged libraries.

This change maintains the default of continuing to keep debug symbols in Meson and CMake projects, but now provides an opt-out via the "--configuration" option.

Note: ideally, this state wouldn't have to be spread over two variables, but I wanted to avoid the potential breakage risk involved with having `opts.configuration` be something other than the common `"debug"` and `"release"` strings, considering how it's used directly in quite a few places.