### PR TITLE
Replace flake8 with ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203, E501
-show-source = True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,36 +4,21 @@ repos:
     hooks:
     - id: black
       language_version: python3
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-        - flake8-encodings==0.5.0.post1
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
       - id: check-yaml
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        additional_dependencies: [toml]
-  - repo: https://github.com/myint/docformatter
-    rev: v1.5.1
-    hooks:
-      - id: docformatter
-        args: [--in-place]
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.2
     hooks:
       - id: shellcheck
         args: [--exclude, SC1017]
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.1
     hooks:
     -   id: mypy
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.242'
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/gvsbuild/deps.py
+++ b/gvsbuild/deps.py
@@ -13,12 +13,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
 #
+"""gvsbuild deps print / .gv graph."""
 
 from typing import List
 
 import typer
 
-"""gvsbuild deps print / .gv graph."""
 # Verify we can import from the script directory
 try:
     import gvsbuild.utils.utils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,6 @@ outdated = ["lastversion", "packaging"]
 [tool.poetry.scripts]
 gvsbuild = 'gvsbuild.main:run'
 
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
-
 [[tool.mypy.overrides]]
 module = "lastversion"
 ignore_missing_imports = true
@@ -59,3 +55,16 @@ python =
 commands = pytest
 deps = pytest
 """
+
+[tool.ruff]
+ignore = ["E501"]
+line-length = 88
+select = [
+    "E",
+    "F",
+    "W",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
[Ruff](https://github.com/charliermarsh/ruff) is a fast linter that is able to replace a few of the tools we have been using, fix more automatically, and uses the pyproject.toml for configuration.