### PR TITLE
Fix UnicodeDecodeError: 'utf-8' can't decode byte

### DIFF
--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -371,14 +371,10 @@ class Builder:
 
             self.__dump_vs_loc()
             log.error_exit(
-                "\n  '%s' could not be found.\n  Please check you have Visual Studio installed at '%s'\n  and that it supports the target platform '%s'."
-                % (vcvars_bat, vs_path, opts.platform)
+                f"\n  {vcvars_bat} could not be found.\n  Please check you have Visual Studio installed at {vs_path}\n  and that it supports the target platform {opts.platform}."
             )
         return subprocess.check_output(
-            f'cmd.exe /c ""{vcvars_bat}"{add_opts}>NUL && set"',
-            encoding="utf-8",
-            shell=True,
-            text=True,
+            f'cmd.exe /c ""{vcvars_bat}"{add_opts}>NUL && set"', text=True
         )
 
     def __find_vs_path_with_vs_version(self, paths):


### PR DESCRIPTION
Fixes #859.

- Removes `encoding="utf-8"` since we need to use the locale encoding.