### PR TITLE
Revert "Update to protobuf version 3.22.0"

### DIFF
--- a/gvsbuild/projects/protobuf.py
+++ b/gvsbuild/projects/protobuf.py
@@ -26,10 +26,10 @@ class Protobuf(Tarball, CmakeProject):
         Project.__init__(
             self,
             "protobuf",
-            version="3.22.0",
+            version="3.21.12",
             lastversion_major=3,
-            archive_url="https://github.com/protocolbuffers/protobuf/releases/download/v{minor}.{micro}/protobuf-{minor}.{micro}.tar.gz",
-            hash="e340f39fad1e35d9237540bcd6a2592ccac353e5d21d0f0521f6ab77370e0142",
+            archive_url="https://github.com/protocolbuffers/protobuf/releases/download/v{minor}.{micro}/protobuf-cpp-{version}.tar.gz",
+            hash="4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c607f73460",
             dependencies=[
                 "cmake",
                 "zlib",


### PR DESCRIPTION
This reverts commit 326c385c1ac7cdf92c31b75d290b9d2cbef56ce5.

Starting from version 22.0 we now get the following error[1]
```
protobuf_ABSL_PROVIDER is "module" but ABSL_ROOT_DIR is wrong
```

We might need to compile ABSL by ourself. Rever the update for now.

[1] https://github.com/protocolbuffers/protobuf/issues/12016