### PR TITLE
Remove yasm

### DIFF
--- a/gvsbuild/groups.py
+++ b/gvsbuild/groups.py
@@ -38,7 +38,6 @@ class Group_Tools(Group):
                 "ninja",
                 "nuget",
                 "perl",
-                "yasm",
             ],
         )
 

--- a/gvsbuild/patches/ffmpeg/0002-fix-msvc-link.patch
+++ b/gvsbuild/patches/ffmpeg/0002-fix-msvc-link.patch
@@ -1,0 +1,11 @@
+diff --git a/configure b/configure
+--- a/configure
++++ b/configure
+@@ -6162,6 +6162,7 @@ EOF
+         test -n "$extern_prefix"  && append X86ASMFLAGS "-DPREFIX"
+         case "$objformat" in
+             elf*) enabled debug && append X86ASMFLAGS $x86asm_debug ;;
++            win*) enabled debug && append X86ASMFLAGS "-g" ;;
+         esac
+ 
+         enabled avx512    && check_x86asm avx512_external    "vmovdqa32 [eax]{k1}{z}, zmm0"

--- a/gvsbuild/patches/ffmpeg/0005-fix-nasm.patch
+++ b/gvsbuild/patches/ffmpeg/0005-fix-nasm.patch
@@ -1,0 +1,69 @@
+diff --git a/libavcodec/x86/Makefile b/libavcodec/x86/Makefile
+--- a/libavcodec/x86/Makefile
++++ b/libavcodec/x86/Makefile
+@@ -138,8 +138,11 @@ X86ASM-OBJS-$(CONFIG_QPELDSP)          += x86/qpeldsp.o                 \
+ X86ASM-OBJS-$(CONFIG_RV34DSP)          += x86/rv34dsp.o
+ X86ASM-OBJS-$(CONFIG_VC1DSP)           += x86/vc1dsp_loopfilter.o       \
+                                           x86/vc1dsp_mc.o
+-X86ASM-OBJS-$(CONFIG_IDCTDSP)          += x86/simple_idct10.o           \
+-                                          x86/simple_idct.o
++ifdef ARCH_X86_64
++X86ASM-OBJS-$(CONFIG_IDCTDSP)          += x86/simple_idct10.o
++else
++X86ASM-OBJS-$(CONFIG_IDCTDSP)          += x86/simple_idct.o
++endif
+ X86ASM-OBJS-$(CONFIG_VIDEODSP)         += x86/videodsp.o
+ X86ASM-OBJS-$(CONFIG_VP3DSP)           += x86/vp3dsp.o
+ X86ASM-OBJS-$(CONFIG_VP8DSP)           += x86/vp8dsp.o                  \
+@@ -157,6 +160,8 @@ X86ASM-OBJS-$(CONFIG_ALAC_DECODER)     += x86/alacdsp.o
+ X86ASM-OBJS-$(CONFIG_APNG_DECODER)     += x86/pngdsp.o
+ X86ASM-OBJS-$(CONFIG_CAVS_DECODER)     += x86/cavsidct.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_CFHD_ENCODER)     += x86/cfhdencdsp.o
++endif
+ X86ASM-OBJS-$(CONFIG_CFHD_DECODER)     += x86/cfhddsp.o
+ X86ASM-OBJS-$(CONFIG_DCA_DECODER)      += x86/dcadsp.o x86/synth_filter.o
+ X86ASM-OBJS-$(CONFIG_DIRAC_DECODER)    += x86/diracdsp.o                \
+@@ -175,15 +180,21 @@                                           x86/hevc_sao_10bit.o
+ X86ASM-OBJS-$(CONFIG_JPEG2000_DECODER) += x86/jpeg2000dsp.o
+ X86ASM-OBJS-$(CONFIG_LSCR_DECODER)     += x86/pngdsp.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_MLP_DECODER)      += x86/mlpdsp.o
++endif
+ X86ASM-OBJS-$(CONFIG_MPEG4_DECODER)    += x86/xvididct.o
+ X86ASM-OBJS-$(CONFIG_PNG_DECODER)      += x86/pngdsp.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_PRORES_DECODER)   += x86/proresdsp.o
+ X86ASM-OBJS-$(CONFIG_PRORES_LGPL_DECODER) += x86/proresdsp.o
++endif
+ X86ASM-OBJS-$(CONFIG_RV40_DECODER)     += x86/rv40dsp.o
+ X86ASM-OBJS-$(CONFIG_SBC_ENCODER)      += x86/sbcdsp.o
+ X86ASM-OBJS-$(CONFIG_SVQ1_ENCODER)     += x86/svq1enc.o
+ X86ASM-OBJS-$(CONFIG_TAK_DECODER)      += x86/takdsp.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_TRUEHD_DECODER)   += x86/mlpdsp.o
++endif
+ X86ASM-OBJS-$(CONFIG_TTA_DECODER)      += x86/ttadsp.o
+ X86ASM-OBJS-$(CONFIG_TTA_ENCODER)      += x86/ttaencdsp.o
+ X86ASM-OBJS-$(CONFIG_UTVIDEO_DECODER)  += x86/utvideodsp.o
+diff --git a/libavfilter/x86/Makefile b/libavfilter/x86/Makefile
+--- a/libavfilter/x86/Makefile
++++ b/libavfilter/x86/Makefile
+@@ -44,6 +44,8 @@ 
+ X86ASM-OBJS-$(CONFIG_AFIR_FILTER)            += x86/af_afir.o
+ X86ASM-OBJS-$(CONFIG_ANLMDN_FILTER)          += x86/af_anlmdn.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_ATADENOISE_FILTER)      += x86/vf_atadenoise.o
++endif
+ X86ASM-OBJS-$(CONFIG_BLEND_FILTER)           += x86/vf_blend.o
+ X86ASM-OBJS-$(CONFIG_BWDIF_FILTER)           += x86/vf_bwdif.o
+ X86ASM-OBJS-$(CONFIG_COLORSPACE_FILTER)      += x86/colorspacedsp.o
+@@ -62,6 +62,8 @@ X86ASM-OBJS-$(CONFIG_LUT3D_FILTER)           += x86/vf_lut3d.o
+ X86ASM-OBJS-$(CONFIG_MASKEDCLAMP_FILTER)     += x86/vf_maskedclamp.o
+ X86ASM-OBJS-$(CONFIG_MASKEDMERGE_FILTER)     += x86/vf_maskedmerge.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_NLMEANS_FILTER)         += x86/vf_nlmeans.o
++endif
+ X86ASM-OBJS-$(CONFIG_OVERLAY_FILTER)         += x86/vf_overlay.o
+ X86ASM-OBJS-$(CONFIG_PP7_FILTER)             += x86/vf_pp7.o
+ X86ASM-OBJS-$(CONFIG_PSNR_FILTER)            += x86/vf_psnr.o

--- a/gvsbuild/projects/ffmpeg.py
+++ b/gvsbuild/projects/ffmpeg.py
@@ -32,7 +32,9 @@ class Ffmpeg(Tarball, Project):
             archive_url="https://ffmpeg.org/releases/ffmpeg-{version}.tar.xz",
             hash="619e706d662c8420859832ddc259cd4d4096a48a2ce1eefd052db9e440eef3dc",
             dependencies=["nasm", "msys2", "pkgconf", "nv-codec-headers"],
-            patches=["0001-libavutil-libavcodec-add-support-for-MB_INFO.patch"],
+            patches=["0001-libavutil-libavcodec-add-support-for-MB_INFO.patch",
+                     "0002-fix-msvc-link.patch",
+                     "0005-fix-nasm.patch"],
         )
         if self.opts.ffmpeg_enable_gpl:
             self.add_dependency("x264")

--- a/gvsbuild/projects/libvpx.py
+++ b/gvsbuild/projects/libvpx.py
@@ -32,7 +32,7 @@ class Libvpx(Tarball, Project):
             archive_url="https://github.com/webmproject/libvpx/archive/v{version}.tar.gz",
             archive_file_name="libvpx-v{version}.tar.gz",
             hash="cb2a393c9c1fae7aba76b950bb0ad393ba105409fe1a147ccd61b0aaa1501066",
-            dependencies=["yasm", "msys2", "libyuv", "perl"],
+            dependencies=["nasm", "msys2", "libyuv", "perl"],
             patches=[
                 "0006-gen_msvs_vcxproj.sh-Select-current-Windows-SDK-if-av.patch",
                 "0001-Always-generate-pc-file.patch",
@@ -41,7 +41,7 @@ class Libvpx(Tarball, Project):
 
     def build(self):
         configure_options = (
-            "--enable-pic --as=yasm --disable-unit-tests --size-limit=16384x16384 "
+            "--enable-pic --as=nasm --disable-unit-tests --size-limit=16384x16384 "
             "--enable-postproc --enable-multi-res-encoding --enable-temporal-denoising "
             "--enable-vp9-temporal-denoising --enable-vp9-postproc --disable-tools "
             "--disable-examples --disable-docs "

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -243,30 +243,6 @@ class ToolPerl(Tool):
 
 
 @tool_add
-class ToolYasm(Tool):
-    def __init__(self):
-        Tool.__init__(
-            self,
-            "yasm",
-            version="1.3.0",
-            archive_url="http://www.tortall.net/projects/yasm/releases/yasm-{version}-win64.exe",
-            hash="d160b1d97266f3f28a71b4420a0ad2cd088a7977c2dd3b25af155652d8d8d91f",
-            dir_part="yasm-{version}",
-            exe_name="yasm.exe",
-        )
-
-    def unpack(self):
-        # We download directly the exe file so we copy it on the tool directory ...
-        self.mark_deps = extract_exec(
-            self.archive_file,
-            self.build_dir,
-            check_file=self.full_exe,
-            force_dest=self.full_exe,
-            check_mark=True,
-        )
-
-
-@tool_add
 class ToolGo(Tool):
     def __init__(self):
         Tool.__init__(


### PR DESCRIPTION
I was experiencing a bug similar to this one with my ffmpeg build hanging in gvsbuild: https://github.com/microsoft/vcpkg/issues/28390

Also I noticed libvpx was failing to build too. After some digging it seems the root cause was yasm failing to run due to a missing msvcrt100.dll. However that file does not seem to be included in the latest VS runtime, and the old VS runtime download links are removed from Microsoft's website. The yasm build used here is 9 years old, ideally it would be updated, but after following the comments in vcpkg issues it seems yasm is unmaintained.

After removing yasm I was able to get ffmpeg and libvpx to build using nasm without any additional DLLs. Those are the only two packages listing yasm as a dependency. The ffmpeg build did need some patches that are included in this PR, taken from the vcpkg fix: https://github.com/microsoft/vcpkg/pull/28955