### PR TITLE
Update ffmpeg to version 6.0

### DIFF
--- a/gvsbuild/patches/ffmpeg/0001-libavutil-libavcodec-add-support-for-MB_INFO.patch
+++ b/gvsbuild/patches/ffmpeg/0001-libavutil-libavcodec-add-support-for-MB_INFO.patch
@@ -1,23 +1,23 @@
-From d2847015f46170289964f428a5d73be9623789b3 Mon Sep 17 00:00:00 2001
+From cb2c6e3314ca8657c21fc6731871aff9f1f548a2 Mon Sep 17 00:00:00 2001
 From: Elias Carotti <eliascrt@amazon.it>
-Date: Thu, 26 May 2022 21:17:43 +0000
-Subject: [PATCH] libavutil,libavcodec: add support for MB_INFO
+Date: Wed, 19 Apr 2023 11:49:39 +0200
+Subject: [PATCH] Add support for x264's MB_INFO
 
 ---
- libavcodec/libx264.c | 21 ++++++++++++++++
- libavutil/Makefile   |  4 ++++
+ libavcodec/libx264.c | 61 ++++++++++++++++++++++++++++++++++++++++++++
+ libavutil/Makefile   |  4 +++
  libavutil/frame.h    | 10 ++++++++
- libavutil/mb_info.c  | 41 +++++++++++++++++++++++++++++++
- libavutil/mb_info.h  | 57 ++++++++++++++++++++++++++++++++++++++++++++
- 5 files changed, 133 insertions(+)
+ libavutil/mb_info.c  | 46 +++++++++++++++++++++++++++++++++
+ libavutil/mb_info.h  | 46 +++++++++++++++++++++++++++++++++
+ 5 files changed, 167 insertions(+)
  create mode 100644 libavutil/mb_info.c
  create mode 100644 libavutil/mb_info.h
 
 diff --git a/libavcodec/libx264.c b/libavcodec/libx264.c
-index 98ec030865..92f3a34a5b 100644
+index cfdd422236..a98d702c92 100644
 --- a/libavcodec/libx264.c
 +++ b/libavcodec/libx264.c
-@@ -29,6 +29,7 @@
+@@ -30,6 +30,7 @@
  #include "libavutil/stereo3d.h"
  #include "libavutil/time.h"
  #include "libavutil/intreadwrite.h"
@@ -25,7 +25,17 @@ index 98ec030865..92f3a34a5b 100644
  #include "avcodec.h"
  #include "codec_internal.h"
  #include "encode.h"
-@@ -116,6 +117,8 @@ typedef struct X264Context {
+@@ -48,6 +49,9 @@
+ // from x264.h, for quant_offsets, Macroblocks are 16x16
+ // blocks of pixels (with respect to the luma plane)
+ #define MB_SIZE 16
++#define MB_LSIZE 4
++#define MB_FLOOR(x)      ((x) >> (MB_LSIZE))
++#define MB_CEIL(x)       MB_FLOOR((x) + (MB_SIZE - 1))
+ 
+ typedef struct X264Opaque {
+ #if FF_API_REORDERED_OPAQUE
+@@ -123,6 +127,8 @@ typedef struct X264Context {
       * encounter a frame with ROI side data.
       */
      int roi_warned;
@@ -34,28 +44,79 @@ index 98ec030865..92f3a34a5b 100644
  } X264Context;
  
  static void X264_log(void *p, int level, const char *fmt, va_list args)
-@@ -492,6 +495,20 @@ static int X264_frame(AVCodecContext *ctx, AVPacket *pkt, const AVFrame *frame,
-         }
+@@ -320,6 +326,45 @@ static enum AVPixelFormat csp_to_pixfmt(int csp)
+     return AV_PIX_FMT_NONE;
+ }
+ 
++static int setup_mb_info(AVCodecContext *ctx, x264_picture_t *pic,
++                         const AVFrame *frame, const uint8_t *data,
++                         size_t size)
++{
++    int mb_width = (frame->width + MB_SIZE - 1) / MB_SIZE;
++    int mb_height = (frame->height + MB_SIZE - 1) / MB_SIZE;
++    const AVMBInfoRect *mbinfo_rects;
++    size_t mbinfo_count;
++    uint8_t *mbinfo;
++
++    mbinfo_rects = (const AVMBInfoRect *)data;
++    mbinfo_count = size / sizeof(AVMBInfoRect);
++
++    mbinfo = av_calloc(mb_width * mb_height, sizeof(*mbinfo));
++    if (!mbinfo)
++        return AVERROR(ENOMEM);
++
++    /* Sets the default as constant, i.e. P_SKIP-able, then selectively resets the flag */
++    memset(mbinfo, X264_MBINFO_CONSTANT, sizeof(*mbinfo) * mb_width * mb_height);
++
++    for (int i = 0; i < mbinfo_count; i++) {
++        int min_y = MB_FLOOR(mbinfo_rects->y);
++        int max_y = MB_CEIL(mbinfo_rects->y + mbinfo_rects->height);
++        int min_x = MB_FLOOR(mbinfo_rects->x);
++        int max_x = MB_CEIL(mbinfo_rects->x + mbinfo_rects->width);
++
++        for (int mb_y = min_y; mb_y < max_y; ++mb_y) {
++            memset(mbinfo + mb_y * mb_width + min_x, 0, max_x - min_x);
++        }
++
++        mbinfo_rects++;
++    }
++
++    pic->prop.mb_info = mbinfo;
++    pic->prop.mb_info_free = av_free;
++
++    return 0;
++}
++
+ static int setup_roi(AVCodecContext *ctx, x264_picture_t *pic, int bit_depth,
+                      const AVFrame *frame, const uint8_t *data, size_t size)
+ {
+@@ -404,6 +449,7 @@ static int setup_frame(AVCodecContext *ctx, const AVFrame *frame,
+     int64_t wallclock = 0;
+     int bit_depth, ret;
+     AVFrameSideData *sd;
++    AVFrameSideData *mbinfo_sd;
+ 
+     *ppic = NULL;
+     if (!frame)
+@@ -499,6 +545,17 @@ FF_ENABLE_DEPRECATION_WARNINGS
+             goto fail;
      }
  
-+    if (frame && x4->mb_info) {
-+        AVFrameSideData *mbinfo_sd = av_frame_get_side_data(frame, AV_FRAME_DATA_MB_INFO);
++    mbinfo_sd = av_frame_get_side_data(frame, AV_FRAME_DATA_MB_INFO);
++    if (mbinfo_sd) {
++        int ret = setup_mb_info(ctx, pic, frame, mbinfo_sd->data, mbinfo_sd->size);
++        if (ret < 0) {
++            /* No need to fail here, this is not fatal. We just proceed with no
++             * mb_info and log a message */
 +
-+        if (mbinfo_sd) {
-+            AVMBInfo *par = (AVMBInfo *)mbinfo_sd->data;
-+
-+            x4->pic.prop.mb_info = par->mb_info;
-+            x4->pic.prop.mb_info_free = par->mb_info_free;
-+        } else if (!mbinfo_sd || !mbinfo_sd->data) {
-+            av_log(ctx, AV_LOG_WARNING,
-+                    "mb_info flag set but no actual MB info was provided\n");
++            av_log(ctx, AV_LOG_WARNING, "mb_info setup failure\n");
 +        }
 +    }
 +
-     do {
-         if (x264_encoder_encode(x4->enc, &nal, &nnal, frame? &x4->pic: NULL, &pic_out) < 0)
-             return AVERROR_EXTERNAL;
-@@ -969,6 +986,9 @@ static av_cold int X264_init(AVCodecContext *avctx)
+     if (x4->udu_sei) {
+         for (int j = 0; j < frame->nb_side_data; j++) {
+             AVFrameSideData *side_data = frame->side_data[j];
+@@ -1096,6 +1153,9 @@ static av_cold int X264_init(AVCodecContext *avctx)
          }
      }
  
@@ -65,7 +126,7 @@ index 98ec030865..92f3a34a5b 100644
      // update AVCodecContext with x264 parameters
      avctx->has_b_frames = x4->params.i_bframe ?
          x4->params.i_bframe_pyramid ? 2 : 1 : 0;
-@@ -1176,6 +1196,7 @@ static const AVOption options[] = {
+@@ -1305,6 +1365,7 @@ static const AVOption options[] = {
      { "noise_reduction", "Noise reduction",                               OFFSET(noise_reduction), AV_OPT_TYPE_INT, { .i64 = -1 }, INT_MIN, INT_MAX, VE },
      { "udu_sei",      "Use user data unregistered SEI if available",      OFFSET(udu_sei),  AV_OPT_TYPE_BOOL,   { .i64 = 0 }, 0, 1, VE },
      { "x264-params",  "Override the x264 configuration using a :-separated list of key=value parameters", OFFSET(x264_params), AV_OPT_TYPE_DICT, { 0 }, 0, 0, VE },
@@ -74,10 +135,10 @@ index 98ec030865..92f3a34a5b 100644
  };
  
 diff --git a/libavutil/Makefile b/libavutil/Makefile
-index 9435a0bfb0..623afc00fe 100644
+index dc9012f9a8..e99f448213 100644
 --- a/libavutil/Makefile
 +++ b/libavutil/Makefile
-@@ -90,6 +90,7 @@ HEADERS = adler32.h                                                     \
+@@ -91,6 +91,7 @@ HEADERS = adler32.h                                                     \
            tea.h                                                         \
            tx.h                                                          \
            film_grain_params.h                                           \
@@ -85,7 +146,7 @@ index 9435a0bfb0..623afc00fe 100644
  
  ARCH_HEADERS = bswap.h                                                  \
                 intmath.h                                                \
-@@ -195,6 +196,7 @@ OBJS-$(CONFIG_VAAPI)                    += hwcontext_vaapi.o
+@@ -196,6 +197,7 @@ OBJS-$(CONFIG_VAAPI)                    += hwcontext_vaapi.o
  OBJS-$(CONFIG_VIDEOTOOLBOX)             += hwcontext_videotoolbox.o
  OBJS-$(CONFIG_VDPAU)                    += hwcontext_vdpau.o
  OBJS-$(CONFIG_VULKAN)                   += hwcontext_vulkan.o
@@ -93,7 +154,7 @@ index 9435a0bfb0..623afc00fe 100644
  
  OBJS-$(!CONFIG_VULKAN)                  += hwcontext_stub.o
  
-@@ -218,6 +220,8 @@ SKIPHEADERS-$(CONFIG_VULKAN)           += hwcontext_vulkan.h vulkan.h   \
+@@ -219,6 +221,8 @@ SKIPHEADERS-$(CONFIG_VULKAN)           += hwcontext_vulkan.h vulkan.h   \
                                            vulkan_functions.h            \
                                            vulkan_loader.h
  
@@ -103,13 +164,13 @@ index 9435a0bfb0..623afc00fe 100644
              aes                                                         \
              aes_ctr                                                     \
 diff --git a/libavutil/frame.h b/libavutil/frame.h
-index 33fac2054c..08c84a1b63 100644
+index f85d630c5c..9c0fdcf25d 100644
 --- a/libavutil/frame.h
 +++ b/libavutil/frame.h
-@@ -209,6 +209,16 @@ enum AVFrameSideDataType {
-      * volume transform - CUVA 005.1-2021.
+@@ -214,6 +214,16 @@ enum AVFrameSideDataType {
+      * Ambient viewing environment metadata, as defined by H.274.
       */
-     AV_FRAME_DATA_DYNAMIC_HDR_VIVID,
+     AV_FRAME_DATA_AMBIENT_VIEWING_ENVIRONMENT,
 +
 +    /**
 +     * Provide macro block encoder-specific hinting information for the encoder
@@ -125,10 +186,10 @@ index 33fac2054c..08c84a1b63 100644
  enum AVActiveFormatDescription {
 diff --git a/libavutil/mb_info.c b/libavutil/mb_info.c
 new file mode 100644
-index 0000000000..fa3e097636
+index 0000000000..789ded110f
 --- /dev/null
 +++ b/libavutil/mb_info.c
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,46 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -156,26 +217,31 @@ index 0000000000..fa3e097636
 +#include "mb_info.h"
 +
 +
-+AVMBInfo *av_mb_info_create_side_data(AVFrame *frame, uint8_t* mb_info,
-+                                            void (*mb_info_free)(void *))
++AVMBInfoRect *av_mb_info_create_side_data(AVFrame *frame,
++                                          AVMBInfoRect *rects,
++                                          size_t num_rects)
 +{
-+    AVFrameSideData *side_data = av_frame_new_side_data(frame,
-+                                                        AV_FRAME_DATA_MB_INFO,
-+                                                        sizeof(AVMBInfo));
-+    AVMBInfo *par = (AVMBInfo *)side_data->data;
++    AVFrameSideData *side_data;
++    AVMBInfoRect *par;
 +
-+    par->mb_info = mb_info;
-+    par->mb_info_free = mb_info_free;
++    side_data = av_frame_new_side_data(frame,
++                                       AV_FRAME_DATA_MB_INFO,
++                                       num_rects * sizeof(AVMBInfoRect));
++
++    par  = (AVMBInfoRect *)side_data->data;
++
++    /* Just copies the rects over the newly allocated buffer */
++    memcpy(par, rects, sizeof(AVMBInfoRect) * num_rects);
 +
 +    return par;
 +}
 +
 diff --git a/libavutil/mb_info.h b/libavutil/mb_info.h
 new file mode 100644
-index 0000000000..20c7eea39c
+index 0000000000..5095360ec5
 --- /dev/null
 +++ b/libavutil/mb_info.h
-@@ -0,0 +1,57 @@
+@@ -0,0 +1,46 @@
 +/**
 + * This file is part of FFmpeg.
 + *
@@ -199,40 +265,29 @@ index 0000000000..20c7eea39c
 +
 +#include <stddef.h>
 +#include <stdint.h>
-+
 +#include "libavutil/avassert.h"
 +#include "libavutil/frame.h"
 +
-+
-+typedef struct AVVideoMBInfo {
-+    /**
-+     * The actual mb_info data: one uint8_t per macroblock in raster-scan order.
-+     * Currently the only flag defined in x264.h is X264_MB_INFO_CONSTANT
-+     */
-+    uint8_t *mb_info;
-+
-+    /* An optional pointer (may be NULL) to a de-allocator for the mb_info data */
-+    void (*mb_info_free)(void *);
-+} AVMBInfo;
++typedef struct _AVMBInfoRect {
++    uint32_t x, y;
++    uint32_t width, height;
++} AVMBInfoRect;
 +
 +/**
-+ * Allocate memory for AVMBInfo and initialize the parameters.
-+ * Can freed with a normal av_free() call.
-+ *
-+ * @param out_size if non-NULL, the size in bytes of the resulting data array is
-+ * written here.
-+ */
-+AVMBInfo *av_mb_info_alloc(uint8_t* mb_info, void (*mb_info_free)(void *));
-+
-+/**
-+ * Allocate memory for AVMBInfo in the given AVFrame {@code frame}
++ * Allocate memory for AVMBInfoRect in the given AVFrame {@code frame}
 + * as AVFrameSideData of type AV_FRAME_DATA_MB_INFO
 + * and initializes the variables.
++ * For each unchanged area a rectangle a flag is set in a special vector of
++ * flags to be passed down to libx264 which uses it as a hint to
++ * encode the corresponding macroblock(s) as P_SKIPS.
++ * Portions of the rects which are not on macroblock boundaries are not
++ * handled as P_SKIPS.
 + */
-+AVMBInfo *av_mb_info_create_side_data(AVFrame *frame, uint8_t* mb_info,
-+                                            void (*mb_info_free)(void *));
++AVMBInfoRect *av_mb_info_create_side_data(AVFrame *frame,
++                                          AVMBInfoRect *rects,
++                                          size_t num_rects);
 +
 +#endif /* AVUTIL_MB_INFO_H */
 -- 
-2.36.1
+2.34.1
 

--- a/gvsbuild/projects/ffmpeg.py
+++ b/gvsbuild/projects/ffmpeg.py
@@ -28,9 +28,9 @@ class Ffmpeg(Tarball, Project):
         Project.__init__(
             self,
             "ffmpeg",
-            version="5.1.2",
+            version="6.0",
             archive_url="https://ffmpeg.org/releases/ffmpeg-{version}.tar.xz",
-            hash="619e706d662c8420859832ddc259cd4d4096a48a2ce1eefd052db9e440eef3dc",
+            hash="57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082",
             dependencies=["nasm", "msys2", "pkgconf", "nv-codec-headers"],
             patches=["0001-libavutil-libavcodec-add-support-for-MB_INFO.patch"],
         )


### PR DESCRIPTION
Rewrite patch to support MB_INFO on libx264.
Patch proposed upstream: http://ffmpeg.org/pipermail/ffmpeg-devel/2023-May/309154.html

This supersedes https://github.com/wingtk/gvsbuild/pull/891