### PR TITLE
Update protobuf to 3.23.0, add abseil cpp

### DIFF
--- a/gvsbuild/patches/protobuf/001-absl-dll-not-aliased.patch
+++ b/gvsbuild/patches/protobuf/001-absl-dll-not-aliased.patch
@@ -1,0 +1,21 @@
+Subject: [PATCH] Fix abseil dll namespace
+---
+Index: cmake/abseil-cpp.cmake
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cmake/abseil-cpp.cmake b/cmake/abseil-cpp.cmake
+--- a/cmake/abseil-cpp.cmake	(revision 7949a62bf88e1d4e97c93b3a7b8a8cfb201b713a)
++++ b/cmake/abseil-cpp.cmake	(date 1708228635580)
+@@ -46,8 +46,8 @@
+   # in the minimum version of abseil required by protobuf, it is possible to
+   # always link absl::abseil_dll and absl::abseil_test_dll and remove the if
+   if(protobuf_ABSL_PROVIDER STREQUAL "package")
+-    set(protobuf_ABSL_USED_TARGETS absl::abseil_dll)
+-    set(protobuf_ABSL_USED_TEST_TARGETS absl::abseil_test_dll)
++    set(protobuf_ABSL_USED_TARGETS abseil_dll)
++    set(protobuf_ABSL_USED_TEST_TARGETS abseil_test_dll)
+   else()
+     set(protobuf_ABSL_USED_TARGETS abseil_dll)
+     set(protobuf_ABSL_USED_TEST_TARGETS abseil_test_dll)

--- a/gvsbuild/projects/__init__.py
+++ b/gvsbuild/projects/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 
 from gvsbuild.projects.adwaita_icon_theme import AdwaitaIconTheme
+from gvsbuild.projects.abseil import AbseilCpp
 from gvsbuild.projects.atk import Atk
 from gvsbuild.projects.boringssl import BoringSSL
 from gvsbuild.projects.cairo import Cairo

--- a/gvsbuild/projects/abseil.py
+++ b/gvsbuild/projects/abseil.py
@@ -1,6 +1,4 @@
-#  Copyright (C) 2016 - Yevgen Muntyan
-#  Copyright (C) 2016 - Ignacio Casal Quinteiro
-#  Copyright (C) 2016 - Arnavion
+#  Copyright (C) 2016 The Gvsbuild Authors
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/gvsbuild/projects/abseil.py
+++ b/gvsbuild/projects/abseil.py
@@ -1,0 +1,43 @@
+#  Copyright (C) 2016 - Yevgen Muntyan
+#  Copyright (C) 2016 - Ignacio Casal Quinteiro
+#  Copyright (C) 2016 - Arnavion
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from gvsbuild.utils.base_builders import CmakeProject
+from gvsbuild.utils.base_expanders import Tarball
+from gvsbuild.utils.base_project import Project, project_add
+
+
+@project_add
+class AbseilCpp(Tarball, CmakeProject):
+    def __init__(self):
+        Project.__init__(
+            self,
+            "abseil-cpp",
+            version="20230125.3",
+            archive_url="https://github.com/abseil/abseil-cpp/archive/refs/tags/{version}.tar.gz",
+            archive_file_name="abseil-cpp-{version}.tar.gz",
+            hash="5366d7e7fa7ba0d915014d387b66d0d002c03236448e1ba9ef98122c13b35c36",
+            dependencies=["cmake", "ninja"],
+        )
+
+    def build(self, **kwargs):
+        CmakeProject.build(
+            self,
+            use_ninja=True,
+            cmake_params=r"-DABSL_PROPAGATE_CXX_STD=ON -DABSL_BUILD_DLL=ON",
+        )
+
+        self.install(r".\LICENSE share\doc\abseil-cpp")

--- a/gvsbuild/projects/abseil.py
+++ b/gvsbuild/projects/abseil.py
@@ -26,10 +26,10 @@ class AbseilCpp(Tarball, CmakeProject):
         Project.__init__(
             self,
             "abseil-cpp",
-            version="20230125.3",
+            version="20240116.1",
             archive_url="https://github.com/abseil/abseil-cpp/archive/refs/tags/{version}.tar.gz",
             archive_file_name="abseil-cpp-{version}.tar.gz",
-            hash="5366d7e7fa7ba0d915014d387b66d0d002c03236448e1ba9ef98122c13b35c36",
+            hash="3c743204df78366ad2eaf236d6631d83f6bc928d1705dd0000b872e53b73dc6a",
             dependencies=["cmake", "ninja"],
         )
 

--- a/gvsbuild/projects/protobuf.py
+++ b/gvsbuild/projects/protobuf.py
@@ -35,6 +35,9 @@ class Protobuf(Tarball, CmakeProject):
                 "ninja",
                 "abseil-cpp",
             ],
+            patches=[
+                "001-absl-dll-not-aliased.patch",
+            ],
         )
 
     def build(self):
@@ -43,8 +46,7 @@ class Protobuf(Tarball, CmakeProject):
             self,
             cmake_params=r'-DBUILD_SHARED_LIBS=ON -Dprotobuf_DEBUG_POSTFIX="" -Dprotobuf_BUILD_TESTS=OFF '
             r"-Dprotobuf_WITH_ZLIB=ON -Dprotobuf_MSVC_STATIC_RUNTIME=OFF "
-            r'-Dprotobuf_ABSL_PROVIDER=package -DCMAKE_PREFIX_PATH="%(pkg_dir)s\lib" '
-            r'-Dabsl_DIR="%(pkg_dir)s\lib\cmake\absl"',
+            r'-Dprotobuf_ABSL_PROVIDER=package -DCMAKE_PREFIX_PATH="%(pkg_dir)s\lib" ',
             use_ninja=True,
         )
 

--- a/gvsbuild/projects/protobuf.py
+++ b/gvsbuild/projects/protobuf.py
@@ -25,10 +25,10 @@ class Protobuf(Tarball, CmakeProject):
         Project.__init__(
             self,
             "protobuf",
-            version="3.23.0",
+            version="3.25.3",
             lastversion_major=3,
             archive_url="https://github.com/protocolbuffers/protobuf/releases/download/v{minor}.{micro}/protobuf-{minor}.{micro}.tar.gz",
-            hash="b29fc5fc13926f347b7a8b676ae1e63f7ccdb92c2fc8ca326bc3a883dcc168ac",
+            hash="d19643d265b978383352b3143f04c0641eea75a75235c111cc01a1350173180e",
             dependencies=[
                 "cmake",
                 "zlib",

--- a/gvsbuild/projects/protobuf.py
+++ b/gvsbuild/projects/protobuf.py
@@ -13,6 +13,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+
 from gvsbuild.utils.base_builders import CmakeProject
 from gvsbuild.utils.base_expanders import Tarball
 from gvsbuild.utils.base_project import Project, project_add
@@ -24,14 +25,15 @@ class Protobuf(Tarball, CmakeProject):
         Project.__init__(
             self,
             "protobuf",
-            version="3.21.12",
+            version="3.23.0",
             lastversion_major=3,
-            archive_url="https://github.com/protocolbuffers/protobuf/releases/download/v{minor}.{micro}/protobuf-cpp-{version}.tar.gz",
-            hash="4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c607f73460",
+            archive_url="https://github.com/protocolbuffers/protobuf/releases/download/v{minor}.{micro}/protobuf-{minor}.{micro}.tar.gz",
+            hash="b29fc5fc13926f347b7a8b676ae1e63f7ccdb92c2fc8ca326bc3a883dcc168ac",
             dependencies=[
                 "cmake",
                 "zlib",
                 "ninja",
+                "abseil-cpp",
             ],
         )
 
@@ -39,7 +41,10 @@ class Protobuf(Tarball, CmakeProject):
         # We need to compile with STATIC_RUNTIME off since protobuf-c also compiles with it OFF
         CmakeProject.build(
             self,
-            cmake_params=r'-DBUILD_SHARED_LIBS=ON -Dprotobuf_DEBUG_POSTFIX="" -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_WITH_ZLIB=ON -Dprotobuf_MSVC_STATIC_RUNTIME=OFF',
+            cmake_params=r'-DBUILD_SHARED_LIBS=ON -Dprotobuf_DEBUG_POSTFIX="" -Dprotobuf_BUILD_TESTS=OFF '
+            r"-Dprotobuf_WITH_ZLIB=ON -Dprotobuf_MSVC_STATIC_RUNTIME=OFF "
+            r'-Dprotobuf_ABSL_PROVIDER=package -DCMAKE_PREFIX_PATH="%(pkg_dir)s\lib" '
+            r'-Dabsl_DIR="%(pkg_dir)s\lib\cmake\absl"',
             use_ninja=True,
         )
 

--- a/gvsbuild/projects/protobuf.py
+++ b/gvsbuild/projects/protobuf.py
@@ -57,9 +57,9 @@ class ProtobufC(Tarball, CmakeProject):
         Project.__init__(
             self,
             "protobuf-c",
-            version="1.4.1",
+            version="1.5.0",
             archive_url="https://github.com/protobuf-c/protobuf-c/releases/download/v{version}/protobuf-c-{version}.tar.gz",
-            hash="4cc4facd508172f3e0a4d3a8736225d472418aee35b4ad053384b137b220339f",
+            hash="7b404c63361ed35b3667aec75cc37b54298d56dd2bcf369de3373212cc06fd98",
             dependencies=[
                 "cmake",
                 "protobuf",


### PR DESCRIPTION
This PR add Abeil and updates protobuf to 3.23.0.

TODO:
- [ ] Fix `LINK : fatal error LNK1104: cannot open file 'abseil_dll.lib'`