### PR TITLE
Drop use of yasm

### DIFF
--- a/gvsbuild/groups.py
+++ b/gvsbuild/groups.py
@@ -36,7 +36,6 @@ class GroupTools(Group):
                 "nasm",
                 "ninja",
                 "perl",
-                "yasm",
             ],
         )
 

--- a/gvsbuild/projects/libvpx.py
+++ b/gvsbuild/projects/libvpx.py
@@ -32,7 +32,7 @@ class Libvpx(Tarball, Project):
             archive_url="https://github.com/webmproject/libvpx/archive/v{version}.tar.gz",
             archive_file_name="libvpx-v{version}.tar.gz",
             hash="cb2a393c9c1fae7aba76b950bb0ad393ba105409fe1a147ccd61b0aaa1501066",
-            dependencies=["yasm", "msys2", "libyuv", "perl"],
+            dependencies=["nasm", "msys2", "libyuv", "perl"],
             patches=[
                 "0006-gen_msvs_vcxproj.sh-Select-current-Windows-SDK-if-av.patch",
                 "0001-Always-generate-pc-file.patch",
@@ -41,7 +41,7 @@ class Libvpx(Tarball, Project):
 
     def build(self):
         configure_options = (
-            "--enable-pic --as=yasm --disable-unit-tests --size-limit=16384x16384 "
+            "--enable-pic --as=nasm --disable-unit-tests --size-limit=16384x16384 "
             "--enable-postproc --enable-multi-res-encoding --enable-temporal-denoising "
             "--enable-vp9-temporal-denoising --enable-vp9-postproc --disable-tools "
             "--disable-examples --disable-docs "

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -218,30 +218,6 @@ class ToolPerl(Tool):
 
 
 @tool_add
-class ToolYasm(Tool):
-    def __init__(self):
-        Tool.__init__(
-            self,
-            "yasm",
-            version="1.3.0",
-            archive_url="http://www.tortall.net/projects/yasm/releases/yasm-{version}-win64.exe",
-            hash="d160b1d97266f3f28a71b4420a0ad2cd088a7977c2dd3b25af155652d8d8d91f",
-            dir_part="yasm-{version}",
-            exe_name="yasm.exe",
-        )
-
-    def unpack(self):
-        # We download directly the exe file so we copy it on the tool directory ...
-        self.mark_deps = extract_exec(
-            self.archive_file,
-            self.build_dir,
-            check_file=self.full_exe,
-            force_dest=self.full_exe,
-            check_mark=True,
-        )
-
-
-@tool_add
 class ToolGo(Tool):
     def __init__(self):
         Tool.__init__(


### PR DESCRIPTION
This is an attempt to remove yasm without adding patches now that ffmpeg 6.0 is merged.

I am getting a successful build of ffmpeg and libvpx and this supersedes #902 if we don't need the extra patches.