### PR TITLE
Project gtk3.24: Include patch for crash on copy

### DIFF
--- a/gvsbuild/patches/gtk3/gdk_fix_clipboard.patch
+++ b/gvsbuild/patches/gtk3/gdk_fix_clipboard.patch
@@ -1,0 +1,30 @@
+From 22b091047f6a71670e0bcaad24c0ca5109a07279 Mon Sep 17 00:00:00 2001
+From: Luca Bacci <luca.bacci982@gmail.com>
+Date: Tue, 21 Mar 2023 10:34:32 +0100
+Subject: [PATCH] GdkWin32: Zero-out memory of an allocated struct
+
+Fixes https://gitlab.gnome.org/GNOME/gtk/-/issues/5678
+---
+ gdk/win32/gdkselection-win32.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gdk/win32/gdkselection-win32.c b/gdk/win32/gdkselection-win32.c
+index caa1a86a6de..04c7280f3ad 100644
+--- a/gdk/win32/gdkselection-win32.c
++++ b/gdk/win32/gdkselection-win32.c
+@@ -1968,10 +1968,10 @@ queue_open_clipboard (GdkWin32ClipboardQueueAction  action,
+ 	return;
+     }
+
+-  info = g_slice_new (GdkWin32ClipboardQueueInfo);
++  info = g_slice_new0 (GdkWin32ClipboardQueueInfo);
+
+   info->display = display;
+-  g_set_object (&info->requestor, requestor);
++  info->requestor = g_object_ref (requestor);
+   info->selection = GDK_SELECTION_CLIPBOARD;
+   info->target = target;
+   info->idle_time = 0;
+--
+GitLab
+

--- a/gvsbuild/projects/gtk.py
+++ b/gvsbuild/projects/gtk.py
@@ -101,6 +101,7 @@ class Gtk3(Tarball, Meson):
             dependencies=["atk", "gdk-pixbuf", "pango", "libepoxy"],
             patches=[
                 "gtk_update_icon_cache.patch",
+                "gdk_fix_clipboard.patch",
             ],
         )
         if self.opts.enable_gi:


### PR DESCRIPTION
This includes the patch of upstream [Merge Request 5690](https://gitlab.gnome.org/GNOME/gtk/-/issues/5843), which fixes a crash with GTK3 on Windows when trying to copy text. This has not been released in a new version yet.

Fixes #944 

There has been a recommendation, that we should just switch to using the newest available commit from the 3.24 branch instead, as GTK3 will not get frequent releases anymore, but this seems to me like it would require bigger changes, so I opted for just including the patch.

Setting this to draft while I still test.