### PR TITLE
Upload GTK runtime zip after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,11 @@ jobs:
         run: |
           Move-Item "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
           Move-Item "C:\Program Files\Git\notbin" "C:\Program Files\Git\bin"
+      - name: Copy wheel files
+        run: |
+          New-Item "C:\gtk-build\gtk\x64\release\wheels" -ItemType "directory"
+          Copy-Item (Resolve-Path C:\gtk-build\build\x64\release\pygobject\dist\PyGObject*.whl) "C:\gtk-build\gtk\x64\release\wheels"
+          Copy-Item (Resolve-Path C:\gtk-build\build\x64\release\pycairo\dist\pycairo*.whl) "C:\gtk-build\gtk\x64\release\wheels"
       - name: Archive GTK runtime
         run: 7z a -tzip gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip C:\gtk-build\gtk\x64\release\*
       - name: Upload gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,12 @@ jobs:
         run: |
           Move-Item "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
           Move-Item "C:\Program Files\Git\notbin" "C:\Program Files\Git\bin"
+      - name: Archive GTK runtime
+        run: 7z a -tzip gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip C:\gtk-build\gtk\x64\release\*
+      - name: Upload gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip
+        uses: actions/upload-artifact@v3
+        with:
+          path: gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip
       - name: Create Source Dist and Wheel
         run: poetry build
       - name: Upload gvsbuild-${{ github.event.release.tag_name }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,15 +147,19 @@ jobs:
           Move-Item "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
           Move-Item "C:\Program Files\Git\notbin" "C:\Program Files\Git\bin"
       - name: Copy wheel files
+        if: github.event_name == 'release'
         run: |
           New-Item "C:\gtk-build\gtk\x64\release\wheels" -ItemType "directory"
           Copy-Item (Resolve-Path C:\gtk-build\build\x64\release\pygobject\dist\PyGObject*.whl) "C:\gtk-build\gtk\x64\release\wheels"
           Copy-Item (Resolve-Path C:\gtk-build\build\x64\release\pycairo\dist\pycairo*.whl) "C:\gtk-build\gtk\x64\release\wheels"
       - name: Archive GTK runtime
+        if: github.event_name == 'release'
         run: 7z a -tzip gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip C:\gtk-build\gtk\x64\release\*
       - name: Upload gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip
         uses: actions/upload-artifact@v3
+        if: github.event_name == 'release'
         with:
+          name: gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip
           path: gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip
       - name: Create Source Dist and Wheel
         run: poetry build

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ stack for Windows using Visual Studio. Currently, GTK 3 and GTK 4 are supported.
 If you want to only run GTK on Windows and not build it yourself, you can download
 a zip file from the last release and unzip it to `C:\gtk`.
 
-It comes with GTK, Cairo, PyGObject, Pycairo, GtkSourceView, adwaita-icon-theme and
+It comes with GTK4, Cairo, PyGObject, Pycairo, GtkSourceView5, adwaita-icon-theme, and
 all of their dependencies.
 
 ### Environmental Variables

--- a/README.md
+++ b/README.md
@@ -5,6 +5,36 @@
 This python script helps you build a full [GTK](https://www.gtk.org/) library
 stack for Windows using Visual Studio. Currently, GTK 3 and GTK 4 are supported.
 
+## Install GTK Only
+
+If you want to only run GTK on Windows and not build it yourself, you can download
+a zip file from the last release and unzip it to `C:\gtk`.
+
+It comes with GTK, Cairo, PyGObject, Pycairo, GtkSourceView, adwaita-icon-theme and
+all of their dependencies.
+
+### Environmental Variables
+Finally, add GTK to your environmental variables with:
+
+```PowerShell
+$env:Path = "C:\gtk\bin;" + $env:Path
+$env:LIB = "C:\gtk\lib;" + $env:LIB
+$env:INCLUDE = "C:\gtk\include;C:\gtk\include\cairo;C:\gtk\include\glib-2.0;C:\gtk\include\gobject-introspection-1.0;C:\gtk\lib\glib-2.0\include;" + $env:INCLUDE
+```
+
+### PyGObject and PyCairo
+
+If you are going to use PyGObject and Pycairo, you also need to use the gvsbuild
+generated wheels with your [Python virtualenv](https://docs.python.org/3/tutorial/venv.html)
+in order to work around this [PyGObject bug](https://gitlab.gnome.org/GNOME/pygobject/-/issues/545):
+
+```PowerShell
+pip install --force-reinstall (Resolve-Path C:\gtk\wheels\PyGObject*.whl)
+pip install --force-reinstall (Resolve-Path C:\gtk\wheels\pycairo*.whl)
+```
+
+## Build GTK
+
 The script supports multiple versions of Visual Studio - at the moment we are
 focusing on VS 2022, but we include projects for other versions, and we gladly
 accept patches.
@@ -30,9 +60,9 @@ SHA256 hash of each download. Downloads are done using TLS, using SSL
 certificates provided by the system, but in case of error the download is tried
 again ignoring certificate errors.
 
-## Development Environment
+### Development Environment
 
-### Choco
+#### Choco
 We recommend using [Chocolately](https://chocolatey.org/) as a package manager
 in Windows.
 
@@ -45,8 +75,7 @@ To run local scripts in follow-on steps, also execute
 `Set-ExecutionPolicy RemoteSigned`. This allows for local PowerShell scripts
 to run without signing, but still requires signing for remote scripts.
 
-### Git
-
+#### Git
 To setup a development environment in Windows install
 [Git](https://gitforwindows.org) by executing as an administrator:
 
@@ -54,7 +83,7 @@ To setup a development environment in Windows install
 choco install git
 ```
 
-### MSYS2
+#### MSYS2
 Both of the development environments in the next steps need MSYS2 installed.
 
 Install [MSYS2](http://www.msys2.org/):
@@ -64,7 +93,7 @@ Keep PowerShell open as administrator and execute:
 choco install msys2
 ```
 
-### Building GTK
+#### Building GTK
 
 First we will install the gvsbuild dependencies:
 1. Visual C++ build tools workload for Visual Studio 2022 Build Tools

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ a zip file from the last release and unzip it to `C:\gtk`.
 It comes with GTK4, Cairo, PyGObject, Pycairo, GtkSourceView5, adwaita-icon-theme, and
 all of their dependencies.
 
+Note however that these binaries are provided “AS IS”, WITHOUT WARRANTY OF ANY KIND.
+They just contain the output of our latest CI run. They are not tested, and we cannot
+commit to timely updates even for security issues. We strongly recommend to build your
+own binaries, especially if you plan to distribute them with your application or use them in
+production.
+
 ### Environmental Variables
 Finally, add GTK to your environmental variables with:
 


### PR DESCRIPTION
Closes #145 by zipping up the built runtime and uploading it.