### PR TITLE
Test with Python 3.12, Bump Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     name: Test with Python ${{ matrix.python-version }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     runs-on: windows-latest
     timeout-minutes: 60
     if: "!contains(github.event.head_commit.message, 'skip ci')"
@@ -46,6 +46,7 @@ jobs:
         uses: actions/setup-python@v4.6.1
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Use Python Dependency Cache
         uses: actions/cache@v3.3.1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gvsbuild"
-version = "2023.6.0"
+version = "2023.7.0"
 description = "GTK stack for Windows"
 authors = ["Ignacio Casal Quinteiro <qignacio@amazon.com>", "Dan Yeaw <dan@yeaw.me>"]
 license = "GPL-2.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ skip = ".venv"
 legacy_tox_ini = """
 [tox]
 isolated_build = true
-envlist = py38, py39, py310, py311
+envlist = py{38,39,310,311,312}
 
 [gh-actions]
 python =
@@ -50,6 +50,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 commands = pytest


### PR DESCRIPTION
Python 3.12 is at beta 3. It is time to start testing with it, so we can switch to it being the primary version once 3.12.0 is out.