### PR TITLE
Fix pixman's pkgconfig file

### DIFF
--- a/gvsbuild/patches/pixman/pc-files/pixman-1.pc
+++ b/gvsbuild/patches/pixman/pc-files/pixman-1.pc
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: Pixman
+Description: The pixman library (version 1)
+Version: @version@
+Cflags: -I${includedir}/pixman-1
+Libs: -L${libdir} -lpixman-1
+

--- a/gvsbuild/projects/pixman.py
+++ b/gvsbuild/projects/pixman.py
@@ -47,8 +47,10 @@ class Pixman(Tarball, Project):
         )
 
         self.install(r".\pixman\%(configuration)s\pixman-1.lib lib")
+        self.install(r".\pixman\%(configuration)s\pixman-1.pc lib\pkgconfig")
 
         self.install(r".\pixman\pixman.h include\pixman-1")
         self.install(r".\pixman\pixman-version.h include\pixman-1")
 
+        self.install_pc_files()
         self.install(r".\COPYING share\doc\pixman")


### PR DESCRIPTION
This should fix an issue when building cairo, as it won't find pixman-1 on pkgconfig, it will try to download from git which normally works unless you have git in a different path like installed by scoop.