### PR TITLE
Fix expat/fontconfig debug/release DLL

### DIFF
--- a/gvsbuild/projects/expat.py
+++ b/gvsbuild/projects/expat.py
@@ -44,11 +44,11 @@ class Expat(Tarball, CmakeProject):
             # Fontconfig is looking for libexpat, not libexpatd
             bin_dir = Path(self.builder.gtk_dir) / "bin"
             self.builder.exec_msys(
-                ["mv", "libexpatd.dll", "libexpat.dll"],
+                ["mv", "libexpatd.dll", "libexpatd.dll"],
                 working_dir=bin_dir,
             )
             lib_dir = Path(self.builder.gtk_dir) / "lib"
             self.builder.exec_msys(
-                ["mv", "libexpatd.lib", "libexpat.lib"],
+                ["mv", "libexpatd.lib", "libexpatd.lib"],
                 working_dir=lib_dir,
             )


### PR DESCRIPTION
Had a step which copied debug build names to release, thus causing upstream builds (fontconfig for example) to fail. I've kept the copy code but fix the naming on the basis of it being minimally intrusive.