### PR TITLE
Fix paths with spaces in meson_params

### DIFF
--- a/gvsbuild/projects/gobject_introspection.py
+++ b/gvsbuild/projects/gobject_introspection.py
@@ -61,6 +61,5 @@ class GObjectIntrospection(Tarball, Meson):
 
         Meson.build(
             self,
-            meson_params="-Dpython=%s\\python.exe -Dcairo_libname=cairo-gobject-2.dll"
-            % (py_dir,),
+            meson_params=f'-Dpython="{py_dir}\\python.exe" -Dcairo_libname=cairo-gobject-2.dll',
         )

--- a/gvsbuild/projects/gstreamer.py
+++ b/gvsbuild/projects/gstreamer.py
@@ -117,7 +117,7 @@ class GstPluginsBase(Tarball, Meson):
 
     def build(self):
         Meson.build(
-            self, meson_params=f"-Dc_link_args={self.builder.gtk_dir}\\lib\\ogg.lib"
+            self, meson_params=f'-Dc_link_args="{self.builder.gtk_dir}\\lib\\ogg.lib"'
         )
         self.install(r".\COPYING share\doc\gst-plugins-base")
 


### PR DESCRIPTION
This PR fixes #1018 by wrapping paths passed in as meson parameters with a double quote so that they aren't split at the space.