### PR TITLE
Add libfido2 project

### DIFF
--- a/gvsbuild/patches/libfido2/0001-libfido2-update-cmake-script-to-have-sdl-flag-before.patch
+++ b/gvsbuild/patches/libfido2/0001-libfido2-update-cmake-script-to-have-sdl-flag-before.patch
@@ -1,0 +1,30 @@
+From c3c7343d3a18de2f00f288db4969ec07cb1fae09 Mon Sep 17 00:00:00 2001
+From: Mofidul Jamal <mofidulj@amazon.com>
+Date: Fri, 18 Aug 2023 14:11:21 -0400
+Subject: [PATCH] libfido2: update cmake script to have /sdl flag before -W4
+ and warning disabled flags
+
+---
+ CMakeLists.txt | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6fa341a..e97976c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -209,9 +209,9 @@ if(MSVC)
+ 	string(REPLACE "C" " -wd" MSVC_DISABLED_WARNINGS_STR
+ 	    ${MSVC_DISABLED_WARNINGS_LIST})
+ 	string(REGEX REPLACE "[/-]W[1234][ ]?" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -MP -W4 -WX ${MSVC_DISABLED_WARNINGS_STR}")
+-	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /Od /Z7 /guard:cf /sdl /RTCcsu")
+-	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Zi /guard:cf /sdl")
++	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /sdl -MP -W4 -WX ${MSVC_DISABLED_WARNINGS_STR}")
++	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /Od /Z7 /guard:cf /RTCcsu")
++	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Zi /guard:cf")
+ 	if(USE_WINHELLO)
+ 		add_definitions(-DUSE_WINHELLO)
+ 	endif()
+-- 
+2.37.1.windows.1
+

--- a/gvsbuild/projects/__init__.py
+++ b/gvsbuild/projects/__init__.py
@@ -49,9 +49,11 @@ from gvsbuild.projects.leveldb import LevelDB
 from gvsbuild.projects.lgi import Lgi
 from gvsbuild.projects.libadwaita import Libadwaita
 from gvsbuild.projects.libarchive import Libarchive
+from gvsbuild.projects.libcbor import Libcbor
 from gvsbuild.projects.libcroco import Libcroco
 from gvsbuild.projects.libcurl import Libcurl
 from gvsbuild.projects.libepoxy import Libepoxy
+from gvsbuild.projects.libfido2 import Libfido2
 from gvsbuild.projects.libffi import Libffi
 from gvsbuild.projects.libgxps import Libgxps
 from gvsbuild.projects.libjpeg_turbo import LibjpegTurbo

--- a/gvsbuild/projects/libcbor.py
+++ b/gvsbuild/projects/libcbor.py
@@ -1,0 +1,27 @@
+from gvsbuild.utils.base_project import Project, project_add
+from gvsbuild.utils.base_expanders import GitRepo
+from gvsbuild.utils.base_builders import CmakeProject
+import os
+
+@project_add
+class Libcbor(GitRepo, CmakeProject):
+    def __init__(self):
+        Project.__init__(
+            self,
+            'libcbor',
+            repo_url = 'https://github.com/PJK/libcbor.git',
+            tag = 'v0.10.2',
+            fetch_submodules = False,
+            dependencies=[
+            "cmake",
+            "ninja"],
+            )
+
+    def build(self):
+        # If do_install is True, the build fails
+        CmakeProject.build(self, use_ninja=True, do_install=False)
+        self.install(r"_gvsbuild-cmake\src\cbor.lib lib")
+        self.install(r"_gvsbuild-cmake\src\cbor\*.h include\cbor")
+        self.install(r"_gvsbuild-cmake\cbor\*.h include\cbor")
+        self.install(r"src\cbor.h include")
+        self.install(r"src\cbor\*.h include\cbor")

--- a/gvsbuild/projects/libfido2.py
+++ b/gvsbuild/projects/libfido2.py
@@ -1,0 +1,36 @@
+from gvsbuild.utils.base_project import Project, project_add
+from gvsbuild.utils.base_expanders import GitRepo
+from gvsbuild.utils.base_builders import CmakeProject
+import os
+
+@project_add
+class Libfido2(GitRepo, CmakeProject):
+    def __init__(self):
+        Project.__init__(
+            self,
+            'libfido2',
+            repo_url = 'https://github.com/Yubico/libfido2.git',
+            tag = '1.13.0',
+            fetch_submodules = False,
+            patches = ['0001-libfido2-update-cmake-script-to-have-sdl-flag-before.patch'],
+            dependencies=[
+            "zlib",
+            "openssl",
+            "libcbor"],
+            )
+
+    def build(self):
+        if self.builder.x86:
+            arch = "x86"
+        else:
+            arch = 'x64'
+
+        include_dirs = os.path.join(self.builder.gtk_dir, "inc")
+        lib_dirs = os.path.join(self.builder.gtk_dir, "lib")
+        bin_dirs = lib_dirs = os.path.join(self.builder.gtk_dir, "bin")
+        #Build static libs only for libfido2
+        build_params = '-DBUILD_EXAMPLES=OFF -DBUILD_MANPAGES=OFF -DBUILD_TESTS=OFF -DBUILD_TOOLS=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS_DEBUG="/MTd /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE" -DCMAKE_C_FLAGS_RELEASE="/MT /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE"'
+        cmake_params = f"-DWITH_ZLIB=ON -DCBOR_INCLUDE_DIRS={include_dirs} -DCRYPTO_INCLUDE_DIRS={include_dirs} -DZLIB_INCLUDE_DIRS={include_dirs} -DCBOR_LIBRARY_DIRS={lib_dirs} -DCRYPTO_LIBRARY_DIRS={lib_dirs} -DZLIB_LIBRARY_DIRS={lib_dirs} -DCBOR_BIN_DIRS={bin_dirs} -DCRYPTO_BIN_DIRS={bin_dirs} -DZLIB_BIN_DIRS={bin_dirs} {build_params}"
+        
+        CmakeProject.build(self, cmake_params=cmake_params, use_ninja=True)
+        self.install(r'output\%s\static\* .' % (arch))


### PR DESCRIPTION
Adding the libfido2 project. Currently supported to build static libraries.

This also adds the libcbor project, as it is a dependency.
This adds OpenSSL as a dependency to libfido2, and builds it directly from makefile instead of the windows powershell script.
Some patches are applied to the libfido2 makefile to reorder security checks in order to compile properly with OpenSSL 3.0 deprecation warnings.