### PR TITLE
x264: Don't quote $extra_flags

### DIFF
--- a/gvsbuild/patches/x264/build/build.sh
+++ b/gvsbuild/patches/x264/build/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-prefix=$1
-build_type=$2
+prefix="$1"
+build_type="$2"
 
 extra_flags=""
 extra_cflags="-DNO_PREFIX"

--- a/gvsbuild/patches/x264/build/build.sh
+++ b/gvsbuild/patches/x264/build/build.sh
@@ -12,4 +12,6 @@ if [ "$build_type" = "debug" ]; then
 fi
 
 CC=cl ./configure --enable-shared --prefix="$prefix" "$extra_flags" --extra-cflags="$extra_cflags"
+
+make
 make install

--- a/gvsbuild/patches/x264/build/build.sh
+++ b/gvsbuild/patches/x264/build/build.sh
@@ -3,15 +3,20 @@
 prefix="$1"
 build_type="$2"
 
-extra_flags=""
-extra_cflags="-DNO_PREFIX"
+declare -a configure_cmd
+declare -i idx=0
+
+configure_cmd[idx++]="./configure"
+configure_cmd[idx++]="--prefix=\"$prefix\""
+configure_cmd[idx++]="--enable-shared"
+configure_cmd[idx++]="--extra-cflags=-DNO_PREFIX"
 
 if [ "$build_type" = "debug" ]; then
-    extra_flags="--enable-debug $extra_flags"
-    extra_cflags="-MDd -Od -Zi $extra_cflags"
+    configure_cmd[idx++]="--enable-debug"
+    configure_cmd[idx++]="--extra-cflags=-MDd -Od -Zi"
 fi
 
-CC=cl ./configure --enable-shared --prefix="$prefix" "$extra_flags" --extra-cflags="$extra_cflags"
+CC=cl "${configure_cmd[@]}"
 
 make
 make install


### PR DESCRIPTION
Otherwise the tailing space is taken into account as part of the option.
```
Building project x264 (git/bfc87b7a330f75f5c9a21e56081e4b20344f139e)
Unknown option --enable-debug , ignored
```

See the space between `--enable-debug` and the comma. It is not supposed to be there:
https://code.videolan.org/videolan/x264/-/blob/bfc87b7a330f75f5c9a21e56081e4b20344f139e/configure#L550