### PR TITLE
x264: pass -Zi in debug-optimized

### DIFF
--- a/gvsbuild/patches/x264/build/build.sh
+++ b/gvsbuild/patches/x264/build/build.sh
@@ -18,6 +18,7 @@ fi
 
 if [ "$build_type" = "debug-optimized" ]; then
     configure_cmd[idx++]="--extra-ldflags=-DEBUG:FULL"
+    configure_cmd[idx++]="--extra-cflags=-Zi"
 fi
 
 CC=cl "${configure_cmd[@]}"


### PR DESCRIPTION
"Use of /Zi doesn't affect optimizations."[1].

[1] https://learn.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format?view=msvc-170#zi