### PR TITLE
boringssl: update to same version boring-sys (rust) version 3

### DIFF
--- a/gvsbuild/projects/boringssl.py
+++ b/gvsbuild/projects/boringssl.py
@@ -29,7 +29,7 @@ class BoringSSL(GitRepo, CmakeProject):
             repository="https://github.com/google/boringssl",
             repo_url="https://github.com/google/boringssl.git",
             fetch_submodules=False,
-            tag="f1c75347daa2ea81a941e953f2263e0a4d970c8d",  # commit from master-with-bazel branch
+            tag="44b3df6f03d85c901767250329c571db405122d5",  # commit from master-with-bazel branch
             dependencies=["cmake", "go", "perl", "nasm", "ninja"],
         )
 


### PR DESCRIPTION
Update boringssl by using the same commit in `boring-sys` version 3.*: https://github.com/cloudflare/boring/tree/v3.0.3/boring-sys/deps