### PR TITLE
Fix release fails for wrong filenames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,6 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 75
     if: "!contains(github.event.head_commit.message, 'skip ci')"
-    outputs:
-      targz: gvsbuild-${{ steps.meta.outputs.version }}.tar.gz
-      wheel: gvsbuild-${{ steps.meta.outputs.version }}-py3-none-any.whl
     strategy:
       matrix:
         gtk-version: ['3', '4']
@@ -174,12 +171,12 @@ jobs:
       - name: Download tar.gz
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: ${{ needs.build.outputs.targz }}
+          name: gvsbuild-${{ github.event.release.tag_name }}.tar.gz
           path: dist
       - name: Download wheel
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: ${{ needs.build.outputs.wheel }}
+          name: gvsbuild-${{ github.event.release.tag_name }}-py3-none-any.whl
           path: dist
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@f5622bde02b04381239da3573277701ceca8f6a0 # release/v1


### PR DESCRIPTION
There is no metadata step to get the version, so downloading of release artifacts failed during the release process.