### PR TITLE
Weekly update 2023-10-15

### DIFF
--- a/gvsbuild/projects/libcurl.py
+++ b/gvsbuild/projects/libcurl.py
@@ -27,10 +27,10 @@ class Libcurl(Tarball, CmakeProject):
         Project.__init__(
             self,
             "libcurl",
-            version="8.3.0",
+            version="8.4.0",
             repository="https://github.com/curl/curl",
             archive_url="https://github.com/curl/curl/releases/download/curl-{major}_{minor}_{micro}/curl-{version}.tar.xz",
-            hash="376d627767d6c4f05105ab6d497b0d9aba7111770dd9d995225478209c37ea63",
+            hash="16c62a9c4af0f703d28bda6d7bbf37ba47055ad3414d70dec63e2e6336f2a82d",
             dependencies=[
                 "perl",
                 "cmake",

--- a/gvsbuild/projects/nghttp2.py
+++ b/gvsbuild/projects/nghttp2.py
@@ -24,9 +24,9 @@ class Nghttp2(Tarball, CmakeProject):
         Project.__init__(
             self,
             "nghttp2",
-            version="1.56.0",
+            version="1.57.0",
             archive_url="https://github.com/nghttp2/nghttp2/releases/download/v{version}/nghttp2-{version}.tar.xz",
-            hash="65eee8021e9d3620589a4a4e91ce9983d802b5229f78f3313770e13f4d2720e9",
+            hash="9210b0113109f43be526ac5835d58a701411821a4d39e155c40d67c40f47a958",
             dependencies=[
                 "cmake",
                 "zlib",

--- a/gvsbuild/projects/pango.py
+++ b/gvsbuild/projects/pango.py
@@ -24,11 +24,10 @@ class Pango(Tarball, Meson):
         Project.__init__(
             self,
             "pango",
-            version="1.50.14",
-            lastversion_even=True,
+            version="1.51.1",
             repository="https://gitlab.gnome.org/GNOME/pango",
-            archive_url="https://download.gnome.org/sources/pango/{major}.{minor}/pango-{version}.tar.xz",
-            hash="1d67f205bfc318c27a29cfdfb6828568df566795df0cb51d2189cde7f2d581e8",
+            archive_url="https://download.gnome.org/sources/pango/{major}.{minor}/pango-1.51.0.tar.xz",
+            hash="74efc109ae6f903bbe6af77eaa2ac6094b8ee245a2e23f132a7a8f0862d1a9f5",
             dependencies=[
                 "ninja",
                 "meson",

--- a/gvsbuild/projects/sqlite.py
+++ b/gvsbuild/projects/sqlite.py
@@ -23,9 +23,9 @@ class SQLite(Tarball, Project):
         Project.__init__(
             self,
             "sqlite",
-            version="3.43.1",
+            version="3.43.2",
             archive_url="https://www.sqlite.org/2023/sqlite-autoconf-{major}{minor:0<3}{micro:0<3}.tar.gz",
-            hash="39116c94e76630f22d54cd82c3cea308565f1715f716d1b2527f1c9c969ba4d9",
+            hash="6d422b6f62c4de2ca80d61860e3a3fb693554d2f75bb1aaca743ccc4d6f609f0",
         )
 
     def build(self):

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -210,9 +210,9 @@ class ToolGo(Tool):
         Tool.__init__(
             self,
             "go",
-            version="1.21.2",
+            version="1.21.3",
             archive_url="https://go.dev/dl/go{version}.windows-amd64.zip",
-            hash="2cd46db02477f33559a4ebf8a176c22879b43fdcfddb1542a23876054f26a83f",
+            hash="27c8daf157493f288d42a6f38debc6a2cb391f6543139eba9152fceca0be2a10",
             dir_part="go-{version}",
         )
 


### PR DESCRIPTION
I *think* that Pango 1.51 is stable, and that they aren't using even / odd versioning - at least Arch and openSUSE have updated to it. There is also an issue with the 1.51.1 release where they tagged it with that version, but the download repo version is 1.51.0. I am using the 1.51.1 version since that seems to be what distros are using.