### PR TITLE
fix: resolution to #1108: `librsvg` fails to build due to unquoted command environment variables

### DIFF
--- a/gvsbuild/projects/librsvg.py
+++ b/gvsbuild/projects/librsvg.py
@@ -48,7 +48,7 @@ class Librsvg(Tarball, Project):
         gtk_dir = self.builder.gtk_dir
         rust_ver = Project.get_project("cargo").version
         python = sys.executable
-        cmd = f"nmake -f makefile.vc CFG={config} \"PREFIX={gtk_dir}\" CARGO=cargo RUSTUP=rustup \"PYTHON={python}\" TOOLCHAIN_VERSION={rust_ver} install"
+        cmd = f'nmake -f makefile.vc CFG={config} "PREFIX={gtk_dir}" CARGO=cargo RUSTUP=rustup "PYTHON={python}" TOOLCHAIN_VERSION={rust_ver} install'
 
         if Project.opts.enable_gi:
             cmd += " INTROSPECTION=1"

--- a/gvsbuild/projects/librsvg.py
+++ b/gvsbuild/projects/librsvg.py
@@ -48,7 +48,7 @@ class Librsvg(Tarball, Project):
         gtk_dir = self.builder.gtk_dir
         rust_ver = Project.get_project("cargo").version
         python = sys.executable
-        cmd = f"nmake -f makefile.vc CFG={config} PREFIX={gtk_dir} CARGO=cargo RUSTUP=rustup PYTHON={python} TOOLCHAIN_VERSION={rust_ver} install"
+        cmd = f"nmake -f makefile.vc CFG={config} \"PREFIX={gtk_dir}\" CARGO=cargo RUSTUP=rustup \"PYTHON={python}\" TOOLCHAIN_VERSION={rust_ver} install"
 
         if Project.opts.enable_gi:
             cmd += " INTROSPECTION=1"


### PR DESCRIPTION
Implements a fix for #1108 by quoting around file paths in `librsvg`.