### PR TITLE
cairo: enable FreeType

### DIFF
--- a/gvsbuild/projects/cairo.py
+++ b/gvsbuild/projects/cairo.py
@@ -33,5 +33,8 @@ class Cairo(Tarball, Meson):
         )
 
     def build(self):
-        Meson.build(self)
+        Meson.build(
+            self,
+            meson_params="-Dfreetype=enabled",
+        )
         self.install(r".\COPYING share\doc\cairo")


### PR DESCRIPTION
Since 1.18.0 cairo disables fontconfig and FreeType by default on Windows and macOS[1][2]. For a successful build libgxps requires cairo-ft.h. Enable FreeType for cairo.

```
../libgxps/gxps-fonts.c(25): fatal error C1083: Cannot open include file: 'cairo-ft.h': No such file or directory
```

It is not clear to me if we should enable also fontconfig. Leave it disabled for now.

[1] https://gitlab.freedesktop.org/cairo/cairo/-/commit/f6a3f6d8add98bf5f15d6fbdc4cd887a0936b531
[2] https://gitlab.freedesktop.org/cairo/cairo/-/commit/a3a7ca452f38413f567a502b97497af0aff0128d