### PR TITLE
Explicitly add `msys2` as path dependency of `libadwaita`

### DIFF
--- a/gvsbuild/projects/libadwaita.py
+++ b/gvsbuild/projects/libadwaita.py
@@ -32,6 +32,7 @@ class Libadwaita(Tarball, Meson):
             dependencies=[
                 "ninja",
                 "meson",
+                "msys2",
                 "pkgconf",
                 "glib",
                 "gtk4",


### PR DESCRIPTION
In `libadwaita` 1.4.0, the `demo/data/meson.build` was changed to require `sh` [1].
However, this is causing a `Program 'sh' not found` error in `gvsbuild` because `sh` isn't on the `$PATH` by default.

Resolve this by adding MSYS2's `sh` to the `$PATH`.

Fixes #1133

[1] https://gitlab.gnome.org/GNOME/libadwaita/-/commit/daeb5a6b78a8530b78f7d495deb02f4e97f26e7b