### PR TITLE
openssl: Update pkg-conf files

### DIFF
--- a/gvsbuild/patches/openssl/pc-files/libcrypto.pc
+++ b/gvsbuild/patches/openssl/pc-files/libcrypto.pc
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+enginesdir=${libdir}/engines-3
+
+Name: OpenSSL-libcrypto
+Description: OpenSSL cryptography library
+Version: @version@
+Libs: -L${libdir} -lcrypto
+Libs.private: -ldl -pthread
+Cflags: -I${includedir}

--- a/gvsbuild/patches/openssl/pc-files/libssl.pc
+++ b/gvsbuild/patches/openssl/pc-files/libssl.pc
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: OpenSSL-libssl
+Description: Secure Sockets Layer and cryptography libraries
+Version: @version@
+Requires.private: libcrypto
+Libs: -L${libdir} -lssl
+Cflags: -I${includedir}

--- a/gvsbuild/patches/openssl/pc-files/openssl.pc
+++ b/gvsbuild/patches/openssl/pc-files/openssl.pc
@@ -1,12 +1,10 @@
-# On windows, the prefix is automagically build from the location of the .pc file
 prefix=@prefix@
 exec_prefix=${prefix}
-libdir=${prefix}/lib
+libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
-Name: openssl
-Description: Cryptography and SSL/TLS Toolkit
+Name: OpenSSL
+Description: Secure Sockets Layer and cryptography libraries and tools
 Version: @version@
+Requires: libssl libcrypto
 
-Libs: -L${libdir} -llibssl -llibcrypto
-Cflags: -I${includedir}/openssl


### PR DESCRIPTION
Mimic what it is done on Linux. One pkg-conf file for each library:
- libcrypto.dll -> libcrypto.pc
- libssl.pc     -> libssl.pc

Then a openssl.pc file that that requires both libraries.