### PR TITLE
openssl: Don't generate documentation

### DIFF
--- a/gvsbuild/projects/openssl.py
+++ b/gvsbuild/projects/openssl.py
@@ -36,9 +36,7 @@ class OpenSSL(Tarball, Project):
         )
 
     def build(self):
-        common_options = (
-            r"no-ssl3 no-comp --openssldir=%(gtk_dir)s/etc/ssl --prefix=%(gtk_dir)s"
-        )
+        common_options = r"no-comp no-docs no-ssl3 --openssldir=%(gtk_dir)s/etc/ssl --prefix=%(gtk_dir)s"
 
         debug_option = "debug-" if self.builder.opts.configuration == "debug" else ""
         # Note that we want to give priority to the system perl version.


### PR DESCRIPTION
Use the newly introduced option[1] no-docs to not generate what we don't need.

[1] https://github.com/openssl/openssl/commit/956b4c75dc3f8710bf7b4e1cf01b4ef6d5ca2b45