### PR TITLE
Revert "Update protobuf-c to version 1.5.0"

### DIFF
--- a/gvsbuild/projects/protobuf.py
+++ b/gvsbuild/projects/protobuf.py
@@ -52,9 +52,9 @@ class ProtobufC(Tarball, CmakeProject):
         Project.__init__(
             self,
             "protobuf-c",
-            version="1.5.0",
+            version="1.4.1",
             archive_url="https://github.com/protobuf-c/protobuf-c/releases/download/v{version}/protobuf-c-{version}.tar.gz",
-            hash="7b404c63361ed35b3667aec75cc37b54298d56dd2bcf369de3373212cc06fd98",
+            hash="4cc4facd508172f3e0a4d3a8736225d472418aee35b4ad053384b137b220339f",
             dependencies=[
                 "cmake",
                 "protobuf",


### PR DESCRIPTION
Like 457db7ce97de982cc75e811403ef79c8ddac84ff, now also protobuf-c requires abseil-cpp as a dependency[1]:
```
Building project protobuf-c (1.5.0)
Generating/updating cmake files
Debug: running cmake -G "Ninja"
[...]
-- Found Protobuf: C:/build/gtk/x64/debug/lib/libprotobuf.lib (found version "3.21.12")
-- Could NOT find absl (missing: absl_DIR)
-- Configuring incomplete, errors occurred!
```

Revert to the previous version for now.

This reverts commit a91caddadc2709d65c39fc408177ebe6f6e34d76.

[1] https://github.com/protobuf-c/protobuf-c/commit/5db0ca5a282630464e0805780c69c779086489d4