### PR TITLE
libgxps: remove gtk dependency

### DIFF
--- a/gvsbuild/projects/libgxps.py
+++ b/gvsbuild/projects/libgxps.py
@@ -37,7 +37,6 @@ class Libgxps(Tarball, Meson):
                 "libpng",
                 "libjpeg-turbo",
                 "libtiff-4",
-                "gtk3",
             ],
         )
         if self.opts.enable_gi:


### PR DESCRIPTION
It is only used for a test and we are already passing enable_test=false.