### PR TITLE
pango: Fix version number to 2.51.0

### DIFF
--- a/gvsbuild/projects/pango.py
+++ b/gvsbuild/projects/pango.py
@@ -24,9 +24,9 @@ class Pango(Tarball, Meson):
         Project.__init__(
             self,
             "pango",
-            version="1.51.1",
+            version="1.51.0",
             repository="https://gitlab.gnome.org/GNOME/pango",
-            archive_url="https://download.gnome.org/sources/pango/{major}.{minor}/pango-1.51.0.tar.xz",
+            archive_url="https://download.gnome.org/sources/pango/{major}.{minor}/pango-{version}.tar.xz",
             hash="74efc109ae6f903bbe6af77eaa2ac6094b8ee245a2e23f132a7a8f0862d1a9f5",
             dependencies=[
                 "ninja",


### PR DESCRIPTION
There is no 2.51.1 release.

Fixes: https://github.com/wingtk/gvsbuild/commit/4475ba40f844352a8739c6d8f19a5484e6227049
