### PR TITLE
Add an option/flag to check the gvsbuild version

### DIFF
--- a/gvsbuild/info.py
+++ b/gvsbuild/info.py
@@ -1,0 +1,10 @@
+import typer
+
+
+def version(active: bool):
+    if not active: return
+    import importlib.metadata
+
+    version = importlib.metadata.version("gvsbuild")
+    typer.echo(f"gvsbuild v{version}")
+    raise typer.Exit()

--- a/gvsbuild/info.py
+++ b/gvsbuild/info.py
@@ -1,8 +1,10 @@
 import typer
 
 
-def version(active: bool):
-    if not active: return
+def version_callback(active: bool):
+    if not active:
+        return
+
     import importlib.metadata
 
     version = importlib.metadata.version("gvsbuild")

--- a/gvsbuild/main.py
+++ b/gvsbuild/main.py
@@ -41,6 +41,7 @@ import gvsbuild.projects  # noqa: F401
 import gvsbuild.tools  # noqa: F401
 from gvsbuild.build import build
 from gvsbuild.outdated import outdated
+from gvsbuild.info import version
 
 rich.reconfigure(markup=False)
 
@@ -50,6 +51,17 @@ app.command(help="")(outdated)
 app.command(help="", name="list")(list_)
 app.command(help="")(deps)
 
+@app.callback()
+def common(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        None,
+        "--version",
+        callback=version,
+        help="Show the app's version"
+    )
+):
+    pass
 
 def run():
     app()

--- a/gvsbuild/main.py
+++ b/gvsbuild/main.py
@@ -40,8 +40,8 @@ import gvsbuild.groups  # noqa: F401
 import gvsbuild.projects  # noqa: F401
 import gvsbuild.tools  # noqa: F401
 from gvsbuild.build import build
+from gvsbuild.info import version_callback
 from gvsbuild.outdated import outdated
-from gvsbuild.info import version
 
 rich.reconfigure(markup=False)
 
@@ -51,17 +51,16 @@ app.command(help="")(outdated)
 app.command(help="", name="list")(list_)
 app.command(help="")(deps)
 
+
 @app.callback()
 def common(
     ctx: typer.Context,
     version: bool = typer.Option(
-        None,
-        "--version",
-        callback=version,
-        help="Show the app's version"
-    )
+        None, "--version", callback=version_callback, help="Show the app's version"
+    ),
 ):
     pass
+
 
 def run():
     app()


### PR DESCRIPTION
Very simple.
Calls `importlib.metadata.version("gvsbuild")` and prints out the output using typer

This PR adds a `--version` flag using a Typer callback _(the `common` function in `main.py`)_
`info.py` might need to be renamed to something more suiting _(explained later why I named it the way I did)_

---
This is my first ever PR, so I apologise if it's a bit rough!
Got inspired to contribute because of a [comment `danyeaw` made](https://github.com/wingtk/gvsbuild/issues/1138#issuecomment-1904949102)

I have an implementation of the `version` function that also prints out the current git repo (if there is one) that I made just for fun, but I removed it for this PR as it seemed confusing to have `--version` print out more than the version and I didn't want to make a separate `--info` flag as it could clutter things up.

Here's that code either way because I am proud of it _(I haven't touched Python in months)_
<details>
    <summary><i>(Click to expand)</i></summary>

    ```py
    def version(active: bool):
        if not active: return

        import importlib.metadata
        from os.path import exists
        import pathlib

        # Printing the version
        version = importlib.metadata.version("gvsbuild")
        typer.echo(f"gvsbuild v{version}")
        
        # Printing additional info for no good reason
        git_path = pathlib.Path(__file__).parent.parent.absolute() / ".git"
        source: str = None
        if exists(git_path):
            import configparser
            config = configparser.ConfigParser()
            config.read(git_path / "config")
            remote = config['remote "origin"']
            if remote:
                url = remote["url"].replace(".git", "")
                repo = url.split('/')[-2:]
                source = "/".join(repo)
        
        if source is None:
            source = "unknown"
        typer.echo(f"source {source}")
        raise typer.Exit()
    ```
</details>