### PR TITLE
Update GStreamer, PCRE2, and Meson

### DIFF
--- a/gvsbuild/patches/pcre2/meson.build
+++ b/gvsbuild/patches/pcre2/meson.build
@@ -1,28 +1,77 @@
-project('pcre2', 'c',
+project(
+  'pcre2',
+  'c',
   license: 'BSD-3',
   meson_version: '>=0.49.0',
-  version: '10.40',
+  version: '10.43',
 )
+
+pcre2_8_lib_version = '0.11.0'
+pcre2_16_lib_version = '0.11.0'
+pcre2_32_lib_version = '0.11.0'
+pcre2_posix_lib_version = '3.0.2'
 
 c_compiler = meson.get_compiler('c')
 
-pcre2_h = configure_file(input : 'src/pcre2.h.generic',
-  output : 'pcre2.h',
-  copy: true)
+platform_is_unixlike = host_machine.system() in [
+  'dragonfly',
+  'freebsd',
+  'netbsd',
+  'openbsd',
+  'haiku',
+  'linux',
+  'android',
+  'darwin',
+  'cygwin'
+]
 
-chartables = configure_file(input : 'src/pcre2_chartables.c.dist',
-  output : 'pcre2_chartables.c',
-  copy: true)
+platform_supports_sljit = host_machine.system() in [
+  'linux',
+  'android',
+  'netbsd'
+]
 
+# pcre2.h
+pcredata = configuration_data()
+varr = meson.project_version().split('.')
+pcredata.set('PCRE2_MAJOR', varr[0])
+pcredata.set('PCRE2_MINOR', varr[1])
+pcredata.set('PCRE2_PRERELEASE', '')
+pcredata.set('PCRE2_DATE', '2022-12-11')
 
-config_h = configure_file(input : 'src/config.h.generic',
-  output : 'config.h',
-  copy: true)
+# config.h
+cdata = configuration_data()
+cdata.set('LINK_SIZE', '2')
+cdata.set('HEAP_LIMIT', '20000000')
+cdata.set('MATCH_LIMIT', '10000000')
+cdata.set('MATCH_LIMIT_DEPTH', 'MATCH_LIMIT')
+cdata.set('NEWLINE_DEFAULT', '2') # default in config.h.generic
+cdata.set('PARENS_NEST_LIMIT', '250')
+cdata.set('PCRE2GREP_BUFSIZE', '20480')
+cdata.set('PCRE2GREP_MAX_BUFSIZE', '1048576')
+cdata.set('MAX_NAME_SIZE', '32')
+cdata.set('MAX_NAME_COUNT', '10000')
+cdata.set('MAX_VARLOOKBEHIND', '255')
 
-sources = [
+jit_deps = []
+if not get_option('jit').disabled() and platform_is_unixlike
+  jit_deps += dependency('threads')
+  cdata.set10('SUPPORT_JIT', true)
+endif
+
+if not get_option('jit_sealloc').disabled()
+  if c_compiler.has_function('mkostemp', prefix: '#include <stdlib.h>', args: ['-D_GNU_SOURCE'])
+    if platform_supports_sljit
+      cdata.set10('SLJIT_PROT_EXECUTABLE_ALLOCATOR', true)
+    elif get_option('jit_sealloc').enabled()
+      error('Your configuration is not supported')
+    endif
+  endif
+endif
+
+sources = files(
   'src/pcre2_auto_possess.c',
-  chartables,
-  config_h, pcre2_h,
+  'src/pcre2_chkdint.c',
   'src/pcre2_compile.c',
   'src/pcre2_config.c',
   'src/pcre2_context.c',
@@ -47,133 +96,194 @@ sources = [
   'src/pcre2_tables.c',
   'src/pcre2_ucd.c',
   'src/pcre2_valid_utf.c',
-  'src/pcre2_xclass.c'
-]
+  'src/pcre2_xclass.c',
+)
 
-includes = [include_directories('.'), include_directories('src')]
+includes = include_directories('.', 'src')
 
 check_headers = [
-  'inttypes.h',
-  'bzlib.h',
   'sys/stat.h',
   'sys/types.h',
-  'sys/wait.h',
-  'inttypes.h',
   'dirent.h',
-  'dlfcn.h',
-  'limits.h',
-  'stdint.h',
-  'stdlib.h',
-  'string.h',
   'windows.h',
-  'unistd.h'
+  'unistd.h',
 ]
 
-config_h_defs = []
 foreach h : check_headers
   if c_compiler.has_header(h)
-    config_h_defs += ['-DHAVE_' + h.underscorify().to_upper()]
+    cdata.set10('HAVE_' + h.underscorify().to_upper(), true)
   endif
 endforeach
 
-
 check_funs = [
-  ['HAVE_STRERROR', 'strerror'],
+  'bcopy',
+  'memfd_create',
+  'memmove',
+  'realpath',
+  'secure_getenv',
+  'strerror',
 ]
 
 foreach f : check_funs
-  if c_compiler.has_function(f.get(1))
-    config_h_defs += ['-D' + f.get(0)]
+  if c_compiler.has_function(f)
+    cdata.set10('HAVE_@0@'.format(f.to_upper()), true)
   endif
 endforeach
 
-
-config_h_defs += ['-DHAVE_MEMMOVE', '-DSTDC_HEADERS', '-DSUPPORT_PCRE2_8', '-DSUPPORT_UNICODE']
+cdata.set10('SUPPORT_PCRE2_8', true)
+cdata.set10('SUPPORT_UNICODE', true)
 
 if get_option('default_library') == 'static'
   static_defs = ['-DPCRE2_STATIC']
-  config_h_defs += static_defs
 else
   static_defs = []
 endif
 
-pcre2_8_lib = library('pcre2-8', sources,
-  include_directories: includes,
-  c_args: config_h_defs + ['-DHAVE_CONFIG_H', '-DPCRE2_CODE_UNIT_WIDTH=8'],
-  install: true)
+pcre2_h = configure_file(
+  input: 'src/pcre2.h.in',
+  output: 'pcre2.h',
+  configuration: pcredata,
+)
 
-pcre2_posix_lib = library('pcre2-posix', ['src/pcre2posix.c', 'src/pcre2posix.h'],
+chartables = configure_file(
+  input: 'src/pcre2_chartables.c.dist',
+  output: 'pcre2_chartables.c',
+  copy: true,
+)
+sources += chartables
+
+config_h = configure_file(
+  output: 'config.h',
+  configuration: cdata,
+)
+
+general_c_args = [static_defs, '-DHAVE_CONFIG_H', '-D_GNU_SOURCE']
+pcre2_8_lib = library(
+  'pcre2-8',
+  sources,
+  dependencies: jit_deps,
   include_directories: includes,
+  c_args: [general_c_args, '-DPCRE2_CODE_UNIT_WIDTH=8'],
+  version: pcre2_8_lib_version,
+  install: true,
+)
+
+libpcre2_8 = declare_dependency(
   link_with: pcre2_8_lib,
-  c_args: config_h_defs + ['-DHAVE_CONFIG_H', '-DPCRE2_CODE_UNIT_WIDTH=8'],
-  install: true)
+  include_directories: includes,
+  compile_args: static_defs,
+)
 
-pcre2_16_lib = library('pcre2-16', sources,
-  include_directories: includes,
-  c_args: config_h_defs + ['-DHAVE_CONFIG_H', '-DPCRE2_CODE_UNIT_WIDTH=16'],
-  install: true)
+pcre2_posix_lib = library(
+  'pcre2-posix',
+  'src/pcre2posix.c',
+  dependencies: libpcre2_8,
+  c_args: [general_c_args, '-DPCRE2_CODE_UNIT_WIDTH=8'],
+  version: pcre2_posix_lib_version,
+  install: true,
+)
 
-pcre2_32_lib = library('pcre2-32', sources,
+libpcre2_posix = declare_dependency(
+  link_with: pcre2_posix_lib,
   include_directories: includes,
-  c_args: config_h_defs + ['-DHAVE_CONFIG_H', '-DPCRE2_CODE_UNIT_WIDTH=32'],
-  install: true)
+  compile_args: static_defs,
+)
 
-libpcre2_8 = declare_dependency(link_with: pcre2_8_lib,
+pcre2_16_lib = library(
+  'pcre2-16',
+  sources,
+  dependencies: jit_deps,
   include_directories: includes,
-  compile_args: static_defs)
-libpcre2_posix = declare_dependency(link_with: pcre2_posix_lib,
+  c_args: [general_c_args, '-DPCRE2_CODE_UNIT_WIDTH=16'],
+  version: pcre2_16_lib_version,
+  install: true,
+)
+
+libpcre2_16 = declare_dependency(
+  link_with: pcre2_16_lib,
   include_directories: includes,
-  compile_args: static_defs)
-libpcre2_16 = declare_dependency(link_with: pcre2_16_lib,
+  compile_args: static_defs,
+)
+
+pcre2_32_lib = library(
+  'pcre2-32',
+  sources,
+  dependencies: jit_deps,
   include_directories: includes,
-  compile_args: static_defs)
-libpcre2_32 = declare_dependency(link_with: pcre2_32_lib,
+  c_args: [general_c_args, '-DPCRE2_CODE_UNIT_WIDTH=32'],
+  version: pcre2_32_lib_version,
+  install: true,
+)
+
+libpcre2_32 = declare_dependency(
+  link_with: pcre2_32_lib,
   include_directories: includes,
-  compile_args: static_defs)
+  compile_args: static_defs,
+)
 
 if get_option('grep')
-  pcre2grep = executable('pcre2grep', ['src/pcre2grep.c'],
-    include_directories: includes,
-    link_with: [pcre2_8_lib],
-    c_args: config_h_defs + ['-DHAVE_CONFIG_H'],
-    install: true)
+  pcre2grep = executable(
+    'pcre2grep',
+    'src/pcre2grep.c',
+    dependencies: libpcre2_8,
+    c_args: general_c_args,
+    install: true,
+  )
 endif
 
-install_headers([pcre2_h, 'src/pcre2posix.h'])
+install_headers(pcre2_h, 'src/pcre2posix.h')
 
 ########### pkg-config #############
 
 pkg = import('pkgconfig')
 
-pkg.generate(pcre2_8_lib,
-             name : 'libpcre2-8',
-             description: 'PCRE2 - Perl compatible regular expressions C library (2nd API) with 8 bit character support',
-             version: meson.project_version())
+pkg.generate(
+  pcre2_8_lib,
+  name: 'libpcre2-8',
+  description: 'PCRE2 - Perl compatible regular expressions C library (2nd API) with 8 bit character support',
+  version: meson.project_version(),
+)
 
-pkg.generate(pcre2_16_lib,
-             name : 'libpcre2-16',
-             description: 'PCRE2 - Perl compatible regular expressions C library (2nd API) with 16 bit character support',
-             version: meson.project_version())
+pkg.generate(
+  pcre2_16_lib,
+  name: 'libpcre2-16',
+  description: 'PCRE2 - Perl compatible regular expressions C library (2nd API) with 16 bit character support',
+  version: meson.project_version(),
+)
 
-pkg.generate(pcre2_32_lib,
-             name : 'libpcre2-32',
-             description: 'PCRE2 - Perl compatible regular expressions C library (2nd API) with 32 bit character support',
-             version: meson.project_version())
-
+pkg.generate(
+  pcre2_32_lib,
+  name: 'libpcre2-32',
+  description: 'PCRE2 - Perl compatible regular expressions C library (2nd API) with 32 bit character support',
+  version: meson.project_version(),
+)
 
 #### tests
 
-if get_option('test') and not meson.is_cross_build() # wine wrappers are not bat-friendly, this would need better testing
+if (
+  get_option('test')
+  and not meson.is_cross_build() # wine wrappers are not bat-friendly, this would need better testing
+)
   link_args = []
   if c_compiler.get_argument_syntax() == 'msvc'
     link_args += '/STACK:2500000'
   endif
 
-  pcre2test = executable('pcre2test', ['src/pcre2test.c'],
-    include_directories: includes,
-    link_with: [pcre2_8_lib, pcre2_posix_lib, pcre2_16_lib, pcre2_32_lib],
-    c_args: config_h_defs + ['-DHAVE_CONFIG_H'],
-    link_args: link_args)
+  pcre2test = executable(
+    'pcre2test',
+    'src/pcre2test.c',
+    dependencies: [libpcre2_8, libpcre2_posix, libpcre2_16, libpcre2_32],
+    c_args: general_c_args,
+    link_args: link_args,
+  )
+
+  pcre2posix_test = executable(
+    'pcre2posix_test',
+    'src/pcre2posix_test.c',
+    dependencies: [libpcre2_8, libpcre2_posix],
+    link_args: link_args,
+  )
+  test('pcre2posix_test', pcre2posix_test)
 
   if c_compiler.get_argument_syntax() == 'msvc'
     runtest = find_program('RunTest.bat')
@@ -183,13 +293,21 @@ if get_option('test') and not meson.is_cross_build() # wine wrappers are not bat
     rungreptest = find_program('RunGrepTest')
   endif
 
-  test('RunTest', runtest,
+  test(
+    'RunTest',
+    runtest,
     should_fail: host_machine.system() == 'windows' and c_compiler.get_argument_syntax() != 'msvc',
-    env : ['srcdir=@0@'.format(meson.current_source_dir())],
-    workdir: meson.current_build_dir())
+    env: 'srcdir=@0@'.format(meson.current_source_dir()),
+    workdir: meson.current_build_dir(),
+  )
 
-  test('RunGrepTest', rungreptest,
-    should_fail: host_machine.system() == 'windows',
-    env : ['srcdir=@0@'.format(meson.current_source_dir())],
-    workdir: meson.current_build_dir())
+  if get_option('grep')
+    test(
+      'RunGrepTest',
+      rungreptest,
+      should_fail: host_machine.system() == 'windows',
+      env: 'srcdir=@0@'.format(meson.current_source_dir()),
+      workdir: meson.current_build_dir(),
+    )
+  endif
 endif

--- a/gvsbuild/patches/pcre2/meson_options.txt
+++ b/gvsbuild/patches/pcre2/meson_options.txt
@@ -3,6 +3,14 @@ option(
   description: 'Compile the PCRE2 grep executable'
 )
 option(
+  'jit', type: 'feature', value: 'enabled',
+  description: 'Support for Just-in-time compiling'
+)
+option(
+  'jit_sealloc', type: 'feature', value: 'enabled',
+  description: 'SELinux compatible execmem allocator in JIT (experimental)'
+)
+option(
   'test', type: 'boolean', value: true,
   description: 'Compile the test executable and enable tests'
 )

--- a/gvsbuild/projects/gstreamer.py
+++ b/gvsbuild/projects/gstreamer.py
@@ -40,10 +40,10 @@ class GStreamer(Tarball, Meson):
             self,
             "gstreamer",
             repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
-            version="1.22.9",
+            version="1.22.10",
             lastversion_even=True,
             archive_url="https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-{version}.tar.xz",
-            hash="1e7124d347e8cdc80f08ec1d370c201be513002af1102bb20e83c5279cb48ebd",
+            hash="969aaef396f252ce925132a4be2aa004e0320f5c1baf0acaaae09c544a6759f4",
             dependencies=["meson", "ninja", "glib", "orc"],
         )
 
@@ -90,10 +90,10 @@ class GstPluginsBase(Tarball, Meson):
             self,
             "gst-plugins-base",
             repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
-            version="1.22.9",
+            version="1.22.10",
             lastversion_even=True,
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-{version}.tar.xz",
-            hash="fac3e0dd2d8e9370388b34bf8c21b89d5f63bc3cfc12cd7fdc8fc6c1cba03334",
+            hash="843a3a2da28e1ee6aeea56dd2be9bffcc3b4bbcd0f974eba4abfc3aa31f0399c",
             dependencies=[
                 "meson",
                 "ninja",
@@ -127,10 +127,10 @@ class GstPluginsGood(Tarball, Meson):
             self,
             "gst-plugins-good",
             repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
-            version="1.22.9",
+            version="1.22.10",
             lastversion_even=True,
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-{version}.tar.xz",
-            hash="26959fcfebfff637d4ea08ef40316baf31b61bb7729820b0684e800c3a1478b6",
+            hash="f748feae922cad62f20102a84ade8f42b78e1e44a34866aa3ea766f9172e1c7f",
             dependencies=[
                 "meson",
                 "ninja",
@@ -154,10 +154,10 @@ class GstPluginsBad(Tarball, Meson):
             self,
             "gst-plugins-bad",
             repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
-            version="1.22.9",
+            version="1.22.10",
             lastversion_even=True,
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-{version}.tar.xz",
-            hash="1bc65d0fd5f53a3636564efd3fcf318c3edcdec39c4109a503c1fc8203840a1d",
+            hash="dabcd60c762165bb043eba753d599212514c94684e4db9a2e25484cb6508ebbf",
             dependencies=["meson", "ninja", "gst-plugins-base"],
             patches=[
                 "wasapisink-reduce-buffer-latency.patch",
@@ -187,10 +187,10 @@ class GstPluginsUgly(Tarball, Meson):
             self,
             "gst-plugins-ugly",
             repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
-            version="1.22.9",
+            version="1.22.10",
             lastversion_even=True,
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-{version}.tar.xz",
-            hash="0bf685d66015a01dd3fc1671b64a1c8acb321dd9d4ab9e05a29ab19782aa6236",
+            hash="cc80a81a22c0b3b31ab7f1b8bf18dda23c72d2791b86cc6264923a68336329ea",
             dependencies=["meson", "ninja", "gst-plugins-base"],
         )
 
@@ -206,10 +206,10 @@ class GstDevTools(Tarball, Meson):
             self,
             "gst-devtools",
             repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
-            version="1.22.9",
+            version="1.22.10",
             lastversion_even=True,
             archive_url="https://gstreamer.freedesktop.org/src/gst-devtools/gst-devtools-{version}.tar.xz",
-            hash="02e29400b44e9cc603aa6444dee5726b57edabef6455e6d0921ffed6f13840ee",
+            hash="0e1ec0d0b8f2d3d314a397399cd01dfc50c02ac088176996f934758119075ea9",
             dependencies=["meson", "ninja", "json-glib"],
         )
 
@@ -233,10 +233,10 @@ class GstPython(Tarball, Meson):
             self,
             "gst-python",
             repository="https://gitlab.freedesktop.org/gstreamer/gstreamer",
-            version="1.22.9",
+            version="1.22.10",
             lastversion_even=True,
             archive_url="https://gstreamer.freedesktop.org/src/gst-python/gst-python-{version}.tar.xz",
-            hash="3f9d5c6ffefda268703744b592a6b3983aa6723273b1220ecbcb62c2a5800009",
+            hash="99e37ea9f7163099734f9b0fce361bc67a0e7a65ffba9bc497127506a3fdedb3",
             dependencies=["meson", "ninja", "pygobject", "gst-plugins-base"],
         )
 

--- a/gvsbuild/projects/pcre2.py
+++ b/gvsbuild/projects/pcre2.py
@@ -9,9 +9,9 @@ class Pcre2(Tarball, Meson):
         Project.__init__(
             self,
             "pcre2",
-            version="10.42",
+            version="10.43",
             archive_url="https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz",
-            hash="c33b418e3b936ee3153de2c61cc638e7e4fe3156022a5c77d0711bcbb9d64f1f",
+            hash="889d16be5abb8d05400b33c25e151638b8d4bac0e2d9c76e9d6923118ae8a34e",
             dependencies=["ninja", "meson", "pkgconf"],
         )
 

--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -93,10 +93,10 @@ class ToolMeson(Tool):
         Tool.__init__(
             self,
             "meson",
-            version="1.3.1",
+            version="1.3.2",
             archive_url="https://github.com/mesonbuild/meson/archive/refs/tags/{version}.tar.gz",
             archive_filename="meson-{version}.tar.gz",
-            hash="274c121edb859602eb4589d31d8791e980748bb19950fc6f611a21d76dc22cc6",
+            hash="683082fb3c5cddf203b21d29bdf4c227e2f7964da5324a15e1a5f7db94322b4b",
             dir_part="meson-{version}",
             exe_name="meson.py",
         )


### PR DESCRIPTION
For PCRE2, I updated the wrapdb files we were using to the latest upstream that support 10.42, and then updated it to work with version 10.43. I upstreamed the changes here:
https://github.com/mesonbuild/wrapdb/pull/1411