### PR TITLE
Build PyGObject and pycairo so wheels are generated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,8 @@ jobs:
       - name: Build GTK4
         if: matrix.gtk-version == '4'
         run: > # Use -j2 option to prevent out of memory errors with GitHub Action runners
-          poetry run gvsbuild build --ninja-opts -j2 --enable-gi --py-wheel cairo gtk4
-          libadwaita gtksourceview5 gobject-introspection adwaita-icon-theme
+          poetry run gvsbuild build --ninja-opts -j2 --enable-gi --py-wheel gobject-introspection
+          gtk4 libadwaita gtksourceview5 pygobject pycairo adwaita-icon-theme
       - name: Restore git binary
         run: |
           Move-Item "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"


### PR DESCRIPTION
This is a follow-up to #1247. We need to build pygobject and pycairo explicitly to generate wheels.