### PR TITLE
Fix incorrect filename syntax for symlink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,21 +133,22 @@ jobs:
           poetry run gvsbuild build --ninja-opts -j2 --enable-gi --py-wheel gobject-introspection
           gtk4 libadwaita gtksourceview5 pygobject pycairo adwaita-icon-theme
       - name: Copy wheel files
-        if: github.event_name == 'release'
+        if: matrix.gtk-version == '4'
         run: |
           New-Item "C:\gtk-build\gtk\x64\release\wheels" -ItemType "directory"
           Copy-Item (Resolve-Path C:\gtk-build\build\x64\release\pygobject\dist\PyGObject*.whl) "C:\gtk-build\gtk\x64\release\wheels"
           Copy-Item (Resolve-Path C:\gtk-build\build\x64\release\pycairo\dist\pycairo*.whl) "C:\gtk-build\gtk\x64\release\wheels"
       - name: Archive GTK runtime
-        if: github.event_name == 'release'
+        if: matrix.gtk-version == '4'
         run: 7z a -tzip gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip C:\gtk-build\gtk\x64\release\*
       - name: Upload gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip
+        if: matrix.gtk-version == '4'
         uses: actions/upload-artifact@v3
-        if: github.event_name == 'release'
         with:
           name: gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip
           path: gtk${{ matrix.gtk-version }}_gvsbuild-${{ github.event.release.tag_name }}_x64.zip
       - name: Create Source Dist and Wheel
+        if: matrix.gtk-version == '4'
         run: poetry build
       - name: Upload gvsbuild-${{ github.event.release.tag_name }}.tar.gz
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1

--- a/gvsbuild/projects/adwaita_icon_theme.py
+++ b/gvsbuild/projects/adwaita_icon_theme.py
@@ -13,6 +13,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 from gvsbuild.utils.base_builders import Meson
 from gvsbuild.utils.base_expanders import Tarball
 from gvsbuild.utils.base_project import project_add
@@ -37,4 +39,16 @@ class AdwaitaIconTheme(Tarball, Meson):
 
     def build(self):
         Meson.build(self)
+        # Work around for https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/issues/282
+        self.builder.exec_msys(
+            [
+                "cp",
+                "--remove-destination",
+                "places/folder.svg",
+                "status/folder-open.svg",
+            ],
+            working_dir=os.path.join(
+                self.builder.gtk_dir, "share", "icons", "Adwaita", "scalable"
+            ),
+        )
         self.install(r".\COPYING_CCBYSA3 share\doc\adwaita-icon-theme")


### PR DESCRIPTION
One of the adwaita-icon-theme files is causing the creation of the zip to fail:

```
C:\gtk-build\gtk\x64\release\share\icons\Adwaita\scalable\status\folder-open.svg : The filename, directory name, or volume label syntax is incorrect.
```

This folder-open.svg is a symlink. The symlink should work in Windows from the built library, but this PR excludes it for now.