### PR TITLE
Fix adwaita-icon-theme wrong cursor location

### DIFF
--- a/gvsbuild/patches/adwaita-icon-theme/001-fix-relative-cursor-path.patch
+++ b/gvsbuild/patches/adwaita-icon-theme/001-fix-relative-cursor-path.patch
@@ -1,0 +1,25 @@
+Subject: [PATCH] Wrong cursor directory
+---
+Index: meson.build
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/meson.build b/meson.build
+--- a/meson.build	(revision 0d44a3fec0171cb8689e79df0186082907533383)
++++ b/meson.build	(date 1708871122562)
+@@ -27,12 +27,13 @@
+ win32_cursors = command_output.stdout().strip().split('\n')
+ if host_machine.system() == 'windows'
+   cursors_with_rel_path = []
++  icons_dir = get_option('datadir') / 'icons'
+   foreach cursor : win32_cursors
+     cursors_with_rel_path += f'Adwaita/cursors/@cursor@'
+   endforeach
+   install_data(
+     cursors_with_rel_path,
+-    install_dir: adwaita_dir,
++    install_dir: icons_dir,
+     preserve_path: true,
+     install_tag : 'runtime',
+   )

--- a/gvsbuild/projects/adwaita_icon_theme.py
+++ b/gvsbuild/projects/adwaita_icon_theme.py
@@ -32,6 +32,7 @@ class AdwaitaIconTheme(Tarball, Meson):
                 "hicolor-icon-theme",
                 "librsvg",
             ],
+            patches=["001-fix-relative-cursor-path.patch"],
         )
 
     def build(self):


### PR DESCRIPTION
Upstream patch merge request is here: https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/merge_requests/66