### PR TITLE
Dependabot: weekly and grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,21 @@
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+      github-action-updates:
+        patterns:
+          - "*"
     schedule:
-      interval: "daily"
+      interval: weekly
+    labels: ["skip-changelog"]
 
   - package-ecosystem: "pip"
     directory: "/"
+    groups:
+      pip-updates:
+        patterns:
+          - "*"
     schedule:
-      interval: "daily"
+      interval: weekly
+    labels: ["skip-changelog"]


### PR DESCRIPTION
Instead of a separate PR for each dependency update sent daily, this change creates a single PR weekly and groups the updates for each ecosystem.