### PR TITLE
opus: add custom pc file

### DIFF
--- a/gvsbuild/patches/opus/pc-files/opus.pc
+++ b/gvsbuild/patches/opus/pc-files/opus.pc
@@ -1,0 +1,16 @@
+# Opus codec reference implementation pkg-config file
+
+prefix=C:/gtk-build/gtk/x64/release
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: Opus
+Description: Opus IETF audio codec (floating-point build)
+URL: https://opus-codec.org/
+Version: 1.5.1
+Requires:
+Conflicts:
+Libs: -L${libdir} -lopus
+Libs.private: 
+Cflags: -I${includedir}/opus

--- a/gvsbuild/projects/opus.py
+++ b/gvsbuild/projects/opus.py
@@ -40,3 +40,6 @@ class Opus(Tarball, CmakeProject):
             self, use_ninja=True, cmake_params="-DOPUS_BUILD_TESTING=OFF"
         )
         self.install(r"COPYING share\doc\opus")
+
+        # FIXME: remove once we switch back to meson
+        self.install_pc_files()


### PR DESCRIPTION
The pc file provided by cmake is broken so we add
our own one until we switch back to meson