### PR TITLE
Install PC files in the pkg_dir directory

### DIFF
--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -409,7 +409,7 @@ class Project(Generic[P]):
 
     def install_pc_files(self, base_dir="pc-files"):
         """Install, setting dir & version, the .pc files."""
-        pkgconfig_dir = os.path.join(self.builder.gtk_dir, "lib", "pkgconfig")
+        pkgconfig_dir = os.path.join(self.pkg_dir, "lib", "pkgconfig")
         self.builder.make_dir(pkgconfig_dir)
 
         src_dir = os.path.join(self._get_working_dir(), base_dir)

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -413,7 +413,7 @@ class Project(Generic[P]):
         self.builder.make_dir(pkgconfig_dir)
 
         src_dir = os.path.join(self._get_working_dir(), base_dir)
-        log.debug(f"Copy .pc files from {src_dir}")
+        log.debug(f"Copy .pc files from {src_dir} to {pkgconfig_dir}")
         gtk_dir = self.builder.gtk_dir.replace("\\", "/")
         for f in os.scandir(src_dir):
             if f.is_file():


### PR DESCRIPTION
Otherwise we are only able to add PC files. Now instead we are able
to provide PC files that replaces the ones already provided upstream.