### PR TITLE
Revert "Update nghttp2 to version 1.60.0"

### DIFF
--- a/gvsbuild/projects/nghttp2.py
+++ b/gvsbuild/projects/nghttp2.py
@@ -24,9 +24,9 @@ class Nghttp2(Tarball, CmakeProject):
         Project.__init__(
             self,
             "nghttp2",
-            version="1.60.0",
+            version="1.59.0",
             archive_url="https://github.com/nghttp2/nghttp2/releases/download/v{version}/nghttp2-{version}.tar.xz",
-            hash="625d6c3da1d9ca4fd643a638256431ae68fd1901653b2a61a245eea7b261bf4e",
+            hash="fdc9bd71f5cf8d3fdfb63066b89364c10eb2fdeab55f3c6755cd7917b2ec4ffb",
             dependencies=[
                 "cmake",
                 "zlib",


### PR DESCRIPTION
The CMake build is broken:
```
ninja: error: build.ninja:661: multiple rules generate lib/nghttp2.lib
```

This reverts commit 4196db54b6e341e1a6fc8d059b4800b093eaaaa6.