### PR TITLE
Revert "Update glib to version 2.80.0"

### DIFF
--- a/gvsbuild/projects/glib.py
+++ b/gvsbuild/projects/glib.py
@@ -24,11 +24,11 @@ class GLib(Tarball, Meson):
         Project.__init__(
             self,
             "glib",
-            version="2.80.0",
+            version="2.78.4",
             lastversion_even=True,
             repository="https://gitlab.gnome.org/GNOME/glib",
             archive_url="https://download.gnome.org/sources/glib/{major}.{minor}/glib-{version}.tar.xz",
-            hash="8228a92f92a412160b139ae68b6345bd28f24434a7b5af150ebe21ff587a561d",
+            hash="24b8e0672dca120cc32d394bccb85844e732e04fe75d18bb0573b2dbc7548f63",
             dependencies=[
                 "ninja",
                 "meson",


### PR DESCRIPTION
This reverts commit edfc39c55eac4db0ce96745a4ecf8f6df345347e until we update the build order for gobject-introspection circular dependencies.