### PR TITLE
Fix Python Not Found with Meson Error

### DIFF
--- a/gvsbuild/projects/pycairo.py
+++ b/gvsbuild/projects/pycairo.py
@@ -12,7 +12,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
-
+import sys
 from pathlib import Path
 
 from gvsbuild.utils.base_builders import Meson
@@ -33,7 +33,8 @@ class Pycairo(Tarball, Meson):
         )
 
     def build(self):
-        Meson.build(self)
+        py_dir = Path(sys.executable).parent
+        Meson.build(self, meson_params=f'-Dpython="{py_dir}\\python.exe"')
         cairo_inc = Path(self.builder.gtk_dir) / "include" / "cairo"
         self.builder.mod_env("INCLUDE", str(cairo_inc))
         self.exec_vs(r"%(python_dir)s\python.exe -m build")

--- a/gvsbuild/projects/pygobject.py
+++ b/gvsbuild/projects/pygobject.py
@@ -12,7 +12,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
-
+import sys
 from pathlib import Path
 
 from gvsbuild.utils.base_builders import Meson
@@ -38,7 +38,8 @@ class PyGObject(Tarball, Meson):
         )
 
     def build(self):
-        Meson.build(self)
+        py_dir = Path(sys.executable).parent
+        Meson.build(self, meson_params=f'-Dpython="{py_dir}\\python.exe"')
         gtk_dir = self.builder.gtk_dir
         add_inc = [
             str(Path(gtk_dir) / "include" / "cairo"),


### PR DESCRIPTION
In some cases meson does not find python or python for the right arch, fix this by using the projects meson param to specify the python installation currently being used.

https://github.com/doadin/gvsbuild/blob/acd2a4a9faee3d987cfc36b48fa8e7d7d3e52ec8/gvsbuild/projects/gobject_introspection.py#L64

https://github.com/wingtk/gvsbuild/issues/1298
