### PR TITLE
Update libadwaita to version 1.5.0

### DIFF
--- a/gvsbuild/patches/libadwaita/0001-remove-appstream-dependency.patch
+++ b/gvsbuild/patches/libadwaita/0001-remove-appstream-dependency.patch
@@ -1,75 +1,86 @@
 Subject: [PATCH] Remove appstream dependency
+
 ---
-Index: subprojects/appstream.wrap
-===================================================================
-diff --git a/subprojects/appstream.wrap b/subprojects/appstream.wrap
-deleted file mode 100644
---- a/subprojects/appstream.wrap	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ /dev/null	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-@@ -1,5 +0,0 @@
--[wrap-git]
--directory = appstream
--url = https://github.com/ximion/appstream.git
--revision = main
--depth = 1
-Index: tests/org.gnome.Adwaita1.Test.metainfo.xml
-===================================================================
-diff --git a/tests/org.gnome.Adwaita1.Test.metainfo.xml b/tests/org.gnome.Adwaita1.Test.metainfo.xml
-deleted file mode 100644
---- a/tests/org.gnome.Adwaita1.Test.metainfo.xml	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ /dev/null	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-@@ -1,29 +0,0 @@
--<?xml version="1.0" encoding="UTF-8"?>
--<component type="desktop-application">
--  <id>org.gnome.Adwaita1.Test</id>
--  <metadata_license>CC0-1.0</metadata_license>
--  <project_license>LGPL-2.1-or-later</project_license>
--  <launchable type="desktop-id">org.gnome.Adwaita1.Test.desktop</launchable>
--  <developer_name>The GNOME Project</developer_name>
+ demo/adwaita-demo.c                        |  28 ++-
+ demo/adwaita-demo.gresources.xml           |   1 -
+ demo/data/meson.build                      |  19 --
+ demo/meson.build                           |   3 -
+ src/adw-about-dialog.c                     | 219 -----------------
+ src/adw-about-dialog.h                     |   7 -
+ src/adw-about-window.c                     | 259 ++-------------------
+ src/adw-about-window.h                     |  13 +-
+ src/meson.build                            |   8 -
+ subprojects/appstream.wrap                 |   5 -
+ tests/meson.build                          |  16 +-
+ tests/org.gnome.Adwaita1.Test.metainfo.xml |  29 ---
+ tests/test-about-dialog.c                  |  49 ----
+ tests/test-about-window.c                  |  49 ----
+ tests/tests.gresources.xml                 |   6 -
+ 15 files changed, 39 insertions(+), 672 deletions(-)
+ delete mode 100644 subprojects/appstream.wrap
+ delete mode 100644 tests/org.gnome.Adwaita1.Test.metainfo.xml
+ delete mode 100644 tests/tests.gresources.xml
+
+diff --git a/demo/adwaita-demo.c b/demo/adwaita-demo.c
+index f2d25f6e..a023275d 100644
+--- a/demo/adwaita-demo.c
++++ b/demo/adwaita-demo.c
+@@ -1,5 +1,3 @@
+-#include "config.h"
 -
--  <name>Adwaita Test</name>
--
--  <releases>
--    <release version="1.0">
--      <description>
--        <p>Testing Build</p>
--      </description>
--    </release>
--    <release version="0.1">
--      <description>
--        <p>Testing Build Older</p>
--      </description>
--    </release>
--  </releases>
--
--  <project_group>GNOME</project_group>
--
--  <url type="homepage">https://gitlab.gnome.org/GNOME/libadwaita</url>
--  <url type="bugtracker">https://gitlab.gnome.org/GNOME/libadwaita/issues</url>
--  <url type="help">http://www.gnome.org/friends/</url>
--</component>
-Index: tests/tests.gresources.xml
-===================================================================
-diff --git a/tests/tests.gresources.xml b/tests/tests.gresources.xml
-deleted file mode 100644
---- a/tests/tests.gresources.xml	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ /dev/null	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-@@ -1,6 +0,0 @@
--<?xml version="1.0" encoding="UTF-8"?>
--<gresources>
--  <gresource prefix="/org/gnome/Adwaita1/Test">
--    <file compressed="true">org.gnome.Adwaita1.Test.metainfo.xml</file>
--  </gresource>
--</gresources>
-Index: demo/data/meson.build
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
+ #include <glib/gi18n.h>
+ #include <gtk/gtk.h>
+ #include <adwaita.h>
+@@ -57,15 +55,23 @@ show_about (GSimpleAction *action,
+ 
+   debug_info = adw_demo_generate_debug_info ();
+ 
+-  about = adw_about_dialog_new_from_appdata ("/org/gnome/Adwaita1/Demo/org.gnome.Adwaita1.Demo.metainfo.xml", NULL);
+-  adw_about_dialog_set_version (ADW_ABOUT_DIALOG (about), ADW_VERSION_S);
+-  adw_about_dialog_set_debug_info (ADW_ABOUT_DIALOG (about), debug_info);
+-  adw_about_dialog_set_debug_info_filename (ADW_ABOUT_DIALOG (about), "adwaita-1-demo-debug-info.txt");
+-  adw_about_dialog_set_copyright (ADW_ABOUT_DIALOG (about), "© 2017–2022 Purism SPC");
+-  adw_about_dialog_set_developers (ADW_ABOUT_DIALOG (about), developers);
+-  adw_about_dialog_set_designers (ADW_ABOUT_DIALOG (about), designers);
+-  adw_about_dialog_set_artists (ADW_ABOUT_DIALOG (about), designers);
+-  adw_about_dialog_set_translator_credits (ADW_ABOUT_DIALOG (about), _("translator-credits"));
++  about =
++    g_object_new (ADW_TYPE_ABOUT_DIALOG,
++                  "application-icon", "org.gnome.Adwaita1.Demo",
++                  "application-name", _("Adwaita Demo"),
++                  "developer-name", _("The GNOME Project"),
++                  "version", ADW_VERSION_S,
++                  "website", "https://gitlab.gnome.org/GNOME/libadwaita",
++                  "issue-url", "https://gitlab.gnome.org/GNOME/libadwaita/-/issues/new",
++                  "debug-info", debug_info,
++                  "debug-info-filename", "adwaita-1-demo-debug-info.txt",
++                  "copyright", "© 2017–2022 Purism SPC",
++                  "license-type", GTK_LICENSE_LGPL_2_1,
++                  "developers", developers,
++                  "designers", designers,
++                  "artists", designers,
++                  "translator-credits", _("translator-credits"),
++                  NULL);
+ 
+   adw_about_dialog_add_link (ADW_ABOUT_DIALOG (about),
+                              _("_Documentation"),
+diff --git a/demo/adwaita-demo.gresources.xml b/demo/adwaita-demo.gresources.xml
+index 86e6b067..acea0eb3 100644
+--- a/demo/adwaita-demo.gresources.xml
++++ b/demo/adwaita-demo.gresources.xml
+@@ -3,7 +3,6 @@
+   <gresource prefix="/org/gnome/Adwaita1/Demo">
+     <file preprocess="xml-stripblanks" alias="icons/scalable/apps/org.gnome.Adwaita1.Demo.svg">data/org.gnome.Adwaita1.Demo.svg</file>
+     <file preprocess="xml-stripblanks" alias="icons/symbolic/apps/org.gnome.Adwaita1.Demo-symbolic.svg">data/org.gnome.Adwaita1.Demo-symbolic.svg</file>
+-    <file preprocess="xml-stripblanks" alias="org.gnome.Adwaita1.Demo.metainfo.xml">data/org.gnome.Adwaita1.Demo.metainfo.xml</file>
+     <file preprocess="xml-stripblanks">icons/scalable/actions/avatar-delete-symbolic.svg</file>
+     <file preprocess="xml-stripblanks">icons/scalable/actions/avatar-save-symbolic.svg</file>
+     <file preprocess="xml-stripblanks">icons/scalable/actions/clock-alarm-symbolic.svg</file>
 diff --git a/demo/data/meson.build b/demo/data/meson.build
---- a/demo/data/meson.build	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ b/demo/data/meson.build	(date 1702739024177)
-@@ -40,25 +40,6 @@
+index 5d176351..12928ac2 100644
+--- a/demo/data/meson.build
++++ b/demo/data/meson.build
+@@ -34,25 +34,6 @@ appdata_config = configuration_data()
  appdata_config.set('BUILD_VERSION', meson.project_version())
  appdata_config.set('BUILD_DATE', today)
  
@@ -95,14 +106,295 @@ diff --git a/demo/data/meson.build b/demo/data/meson.build
  install_data(
    'org.gnome.Adwaita1.Demo.svg',
    install_dir: datadir / 'icons' / 'hicolor' / 'scalable' / 'apps'
-Index: src/adw-about-window.c
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
+diff --git a/demo/meson.build b/demo/meson.build
+index ca04e31f..d01e1651 100644
+--- a/demo/meson.build
++++ b/demo/meson.build
+@@ -3,7 +3,6 @@ if get_option('examples')
+ subdir('data')
+ 
+ demo_config_data = configuration_data()
+-demo_config_data.set_quoted('ADW_METAINFO', appstream_file.full_path())
+ demo_config_data.set_quoted('ADW_DEMO_VCS_TAG', '@VCS_TAG@')
+ 
+ demo_config_h = vcs_tag(
+@@ -19,8 +18,6 @@ adwaita_demo_resources = gnome.compile_resources(
+    'adwaita-demo.gresources.xml',
+ 
+    c_name: 'adw',
+-   dependencies: appstream_file,
+-   source_dir: meson.current_build_dir(),
+ )
+ 
+ adwaita_demo_sources = [
+diff --git a/src/adw-about-dialog.c b/src/adw-about-dialog.c
+index 1bed7bed..73af0179 100644
+--- a/src/adw-about-dialog.c
++++ b/src/adw-about-dialog.c
+@@ -7,7 +7,6 @@
+ 
+ #include "config.h"
+ #include <glib/gi18n-lib.h>
+-#include <appstream.h>
+ 
+ #include "adw-about-dialog.h"
+ 
+@@ -411,13 +410,6 @@ legal_showing_cb (AdwAboutDialog *self)
+   self->legal_showing_idle_id = 0;
+ }
+ 
+-static gboolean
+-get_release_for_version (AsRelease  *rel,
+-                         const char *version)
+-{
+-  return !g_strcmp0 (as_release_get_version (rel), version);
+-}
+-
+ static void
+ update_credits_legal_group (AdwAboutDialog *self)
+ {
+@@ -1953,179 +1945,6 @@ adw_about_dialog_new (void)
+   return g_object_new (ADW_TYPE_ABOUT_DIALOG, NULL);
+ }
+ 
+-/**
+- * adw_about_dialog_new_from_appdata:
+- * @resource_path: The resource to use
+- * @release_notes_version: (nullable): The version to retrieve release notes for
+- *
+- * Creates a new `AdwAboutDialog` using AppStream metadata.
+- *
+- * This automatically sets the following properties with the following AppStream
+- * values:
+- *
+- * * [property@AboutDialog:application-icon] is set from the `<id>`
+- * * [property@AboutDialog:application-name] is set from the `<name>`
+- * * [property@AboutDialog:developer-name] is set from the `<developer_name>`
+- * * [property@AboutDialog:version] is set from the version of the latest release
+- * * [property@AboutDialog:website] is set from the `<url type="homepage">`
+- * * [property@AboutDialog:support-url] is set from the `<url type="help">`
+- * * [property@AboutDialog:issue-url] is set from the `<url type="bugtracker">`
+- * * [property@AboutDialog:license-type] is set from the `<project_license>`
+- *   If the license type retrieved from AppStream is not listed in
+- *   [enum@Gtk.License], it will be set to `GTK_LICENCE_CUSTOM`.
+- *
+- * If @release_notes_version is not `NULL`,
+- * [property@AboutDialog:release-notes-version] is set to match it, while
+- * [property@AboutDialog:release-notes] is set from the AppStream release
+- * description for that version.
+- *
+- * Returns: the newly created `AdwAboutDialog`
+- *
+- * Since: 1.5
+- */
+-AdwDialog *
+-adw_about_dialog_new_from_appdata (const char *resource_path,
+-                                   const char *release_notes_version)
+-{
+-  AdwAboutDialog *self;
+-  GFile *appdata_file;
+-  char *appdata_uri;
+-  AsMetadata *metadata;
+-  GPtrArray *releases;
+-  AsComponent *component;
+-  char *application_id;
+-  const char *name, *developer_name, *project_license;
+-  const char *issue_url, *support_url, *website_url;
+-  GError *error = NULL;
+-
+-  g_return_val_if_fail (resource_path, NULL);
+-
+-  appdata_uri = g_strconcat ("resource://", resource_path, NULL);
+-  appdata_file = g_file_new_for_uri (appdata_uri);
+-
+-  self = ADW_ABOUT_DIALOG (adw_about_dialog_new ());
+-  metadata = as_metadata_new ();
+-
+-  if (!as_metadata_parse_file (metadata, appdata_file, AS_FORMAT_KIND_UNKNOWN, &error)) {
+-    g_error ("Could not parse metadata file: %s", error->message);
+-    g_clear_error (&error);
+-  }
+-
+-  component = as_metadata_get_component (metadata);
+-
+-  if (component == NULL)
+-    g_error ("Could not find valid AppStream metadata");
+-
+-  application_id = g_strdup (as_component_get_id (component));
+-
+-  if (g_str_has_suffix (application_id, ".desktop")) {
+-    AsLaunchable *launchable;
+-    char *appid_desktop;
+-    GPtrArray *entries = NULL;
+-
+-    launchable = as_component_get_launchable (component,
+-                                              AS_LAUNCHABLE_KIND_DESKTOP_ID);
+-
+-    if (launchable)
+-      entries = as_launchable_get_entries (launchable);
+-
+-    appid_desktop = g_strconcat (application_id, ".desktop", NULL);
+-
+-    if (!entries || !g_ptr_array_find_with_equal_func (entries, appid_desktop,
+-                                                       g_str_equal, NULL))
+-      application_id[strlen(application_id) - 8] = '\0';
+-
+-    g_free (appid_desktop);
+-  }
+-
+-#if AS_CHECK_VERSION (1, 0, 0)
+-  releases = as_release_list_get_entries (as_component_get_releases_plain (component));
+-#else
+-  releases = as_component_get_releases (component);
+-#endif
+-
+-  if (release_notes_version) {
+-    guint release_index = 0;
+-
+-    if (g_ptr_array_find_with_equal_func (releases, release_notes_version,
+-                                         (GEqualFunc) get_release_for_version,
+-                                         &release_index)) {
+-      AsRelease *notes_release;
+-      const char *release_notes, *version;
+-
+-      notes_release = g_ptr_array_index (releases, release_index);
+-
+-      release_notes = as_release_get_description (notes_release);
+-      version = as_release_get_version (notes_release);
+-
+-      if (release_notes && version) {
+-        adw_about_dialog_set_release_notes (self, release_notes);
+-        adw_about_dialog_set_release_notes_version (self, version);
+-      }
+-    } else {
+-      g_critical ("No valid release found for version %s", release_notes_version);
+-    }
+-  }
+-
+-  if (releases->len > 0) {
+-    AsRelease *latest_release = g_ptr_array_index (releases, 0);
+-    const char *version = as_release_get_version (latest_release);
+-
+-    if (version)
+-      adw_about_dialog_set_version (self, version);
+-  }
+-
+-  name = as_component_get_name (component);
+-  project_license = as_component_get_project_license (component);
+-  issue_url = as_component_get_url (component, AS_URL_KIND_BUGTRACKER);
+-  support_url = as_component_get_url (component, AS_URL_KIND_HELP);
+-  website_url = as_component_get_url (component, AS_URL_KIND_HOMEPAGE);
+-
+-#if AS_CHECK_VERSION (0, 16, 4)
+-  developer_name = as_developer_get_name (as_component_get_developer (component));
+-#else
+-  developer_name = as_component_get_developer_name (component);
+-#endif
+-
+-  adw_about_dialog_set_application_icon (self, application_id);
+-
+-  if (name)
+-    adw_about_dialog_set_application_name (self, name);
+-
+-  if (developer_name)
+-    adw_about_dialog_set_developer_name (self, developer_name);
+-
+-  if (project_license) {
+-    int i;
+-
+-    for (i = 0; i < G_N_ELEMENTS (gtk_license_info); i++) {
+-      if (g_strcmp0 (gtk_license_info[i].spdx_id, project_license) == 0) {
+-        adw_about_dialog_set_license_type (self, (GtkLicense) i);
+-        break;
+-      }
+-    }
+-
+-    if (adw_about_dialog_get_license_type (self) == GTK_LICENSE_UNKNOWN)
+-      adw_about_dialog_set_license_type (self, GTK_LICENSE_CUSTOM);
+-  }
+-
+-  if (issue_url)
+-    adw_about_dialog_set_issue_url (self, issue_url);
+-
+-  if (support_url)
+-    adw_about_dialog_set_support_url (self, support_url);
+-
+-  if (website_url)
+-    adw_about_dialog_set_website (self, website_url);
+-
+-  g_object_unref (appdata_file);
+-  g_object_unref (metadata);
+-  g_free (application_id);
+-  g_free (appdata_uri);
+-
+-  return ADW_DIALOG (self);
+-}
+-
+ /**
+  * adw_about_dialog_get_application_icon: (attributes org.gtk.Method.get_property=application-icon)
+  * @self: an about dialog
+@@ -3422,41 +3241,3 @@ adw_show_about_dialog (GtkWidget  *parent,
+ 
+   adw_dialog_present (dialog, parent);
+ }
+-
+-/**
+- * adw_show_about_dialog_from_appdata: (skip)
+- * @parent: the parent widget
+- * @resource_path: The resource to use
+- * @release_notes_version: (nullable): The version to retrieve release notes for
+- * @first_property_name: the name of the first property
+- * @...: value of first property, followed by more pairs of property name and
+- *   value, `NULL`-terminated
+- *
+- * A convenience function for showing an application’s about dialog from
+- * AppStream metadata.
+- *
+- * See [ctor@AboutDialog.new_from_appdata] for details.
+- *
+- * Since: 1.5
+- */
+-void
+-adw_show_about_dialog_from_appdata (GtkWidget  *parent,
+-                                    const char *resource_path,
+-                                    const char *release_notes_version,
+-                                    const char *first_property_name,
+-                                    ...)
+-{
+-  AdwDialog *dialog;
+-  va_list var_args;
+-
+-  g_return_if_fail (GTK_IS_WIDGET (parent));
+-
+-  dialog = adw_about_dialog_new_from_appdata (resource_path,
+-                                              release_notes_version);
+-
+-  va_start (var_args, first_property_name);
+-  g_object_set_valist (G_OBJECT (dialog), first_property_name, var_args);
+-  va_end (var_args);
+-
+-  adw_dialog_present (dialog, parent);
+-}
+diff --git a/src/adw-about-dialog.h b/src/adw-about-dialog.h
+index b41bf11e..2f1d05d0 100644
+--- a/src/adw-about-dialog.h
++++ b/src/adw-about-dialog.h
+@@ -178,11 +178,4 @@ void adw_show_about_dialog (GtkWidget  *parent,
+                             const char *first_property_name,
+                             ...) G_GNUC_NULL_TERMINATED;
+ 
+-ADW_AVAILABLE_IN_1_5
+-void adw_show_about_dialog_from_appdata (GtkWidget  *parent,
+-                                         const char *resource_path,
+-                                         const char *release_notes_version,
+-                                         const char *first_property_name,
+-                                         ...) G_GNUC_NULL_TERMINATED;
+-
+ G_END_DECLS
 diff --git a/src/adw-about-window.c b/src/adw-about-window.c
---- a/src/adw-about-window.c	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ b/src/adw-about-window.c	(date 1702824178498)
+index 6a816177..9c37faf0 100644
+--- a/src/adw-about-window.c
++++ b/src/adw-about-window.c
 @@ -6,7 +6,6 @@
  
  #include "config.h"
@@ -111,7 +403,7 @@ diff --git a/src/adw-about-window.c b/src/adw-about-window.c
  
  #include "adw-about-window.h"
  
-@@ -194,31 +193,30 @@
+@@ -194,32 +193,31 @@
  typedef struct {
    const char *name;
    const char *url;
@@ -139,7 +431,8 @@ diff --git a/src/adw-about-window.c b/src/adw-about-window.c
 -  { N_("GNU Affero General Public License, version 3 only"), "https://www.gnu.org/licenses/agpl-3.0.html", "AGPL-3.0-only" },
 -  { N_("BSD 3-Clause License"), "https://opensource.org/licenses/BSD-3-Clause", "BSD-3-Clause" },
 -  { N_("Apache License, Version 2.0"), "https://opensource.org/licenses/Apache-2.0", "Apache-2.0" },
--  { N_("Mozilla Public License 2.0"), "https://opensource.org/licenses/MPL-2.0", "MPL-2.0" }
+-  { N_("Mozilla Public License 2.0"), "https://opensource.org/licenses/MPL-2.0", "MPL-2.0" },
+-  { N_("BSD Zero-Clause License"), "https://opensource.org/license/0bsd", "0BSD" }
 +  { NULL, NULL },
 +  { NULL, NULL },
 +  { N_("GNU General Public License, version 2 or later"), "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html" },
@@ -157,12 +450,13 @@ diff --git a/src/adw-about-window.c b/src/adw-about-window.c
 +  { N_("GNU Affero General Public License, version 3 only"), "https://www.gnu.org/licenses/agpl-3.0.html" },
 +  { N_("BSD 3-Clause License"), "https://opensource.org/licenses/BSD-3-Clause" },
 +  { N_("Apache License, Version 2.0"), "https://opensource.org/licenses/Apache-2.0" },
-+  { N_("Mozilla Public License 2.0"), "https://opensource.org/licenses/MPL-2.0" }
++  { N_("Mozilla Public License 2.0"), "https://opensource.org/licenses/MPL-2.0" },
++  { N_("BSD Zero-Clause License"), "https://opensource.org/license/0bsd" }
  };
  /* Copied from GTK 4 for consistency with GtkAboutDialog. */
  /* Keep this static assertion updated with the last element of the enumeration,
-@@ -388,13 +386,6 @@
-   return GDK_EVENT_STOP;
+@@ -409,13 +407,6 @@ legal_showing_cb (AdwAboutWindow *self)
+     g_idle_add_once ((GSourceOnceFunc) legal_showing_idle_cb, self);
  }
  
 -static gboolean
@@ -175,7 +469,7 @@ diff --git a/src/adw-about-window.c b/src/adw-about-window.c
  static void
  update_credits_legal_group (AdwAboutWindow *self)
  {
-@@ -1919,179 +1910,6 @@
+@@ -1952,179 +1943,6 @@ adw_about_window_new (void)
    return g_object_new (ADW_TYPE_ABOUT_WINDOW, NULL);
  }
  
@@ -307,7 +601,7 @@ diff --git a/src/adw-about-window.c b/src/adw-about-window.c
 -  support_url = as_component_get_url (component, AS_URL_KIND_HELP);
 -  website_url = as_component_get_url (component, AS_URL_KIND_HOMEPAGE);
 -
--#if AS_CHECK_VERSION (1, 0, 0)
+-#if AS_CHECK_VERSION (0, 16, 4)
 -  developer_name = as_developer_get_name (as_component_get_developer (component));
 -#else
 -  developer_name = as_component_get_developer_name (component);
@@ -355,13 +649,13 @@ diff --git a/src/adw-about-window.c b/src/adw-about-window.c
  /**
   * adw_about_window_get_application_icon: (attributes org.gtk.Method.get_property=application-icon)
   * @self: an about window
-@@ -3389,42 +3207,3 @@
+@@ -3422,42 +3240,3 @@ adw_show_about_window (GtkWindow  *parent,
  
    gtk_window_present (GTK_WINDOW (window));
  }
 -
 -/**
-- * adw_show_about_window_from_appdata:
+- * adw_show_about_window_from_appdata: (skip)
 - * @parent: (nullable): the parent top-level window
 - * @resource_path: The resource to use
 - * @release_notes_version: (nullable): The version to retrieve release notes for
@@ -398,14 +692,223 @@ diff --git a/src/adw-about-window.c b/src/adw-about-window.c
 -
 -  gtk_window_present (GTK_WINDOW (window));
 -}
-Index: tests/test-about-window.c
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
+diff --git a/src/adw-about-window.h b/src/adw-about-window.h
+index 79be5009..e6a041d4 100644
+--- a/src/adw-about-window.h
++++ b/src/adw-about-window.h
+@@ -25,10 +25,6 @@ G_DECLARE_FINAL_TYPE (AdwAboutWindow, adw_about_window, ADW, ABOUT_WINDOW, AdwWi
+ ADW_AVAILABLE_IN_1_2
+ GtkWidget *adw_about_window_new (void) G_GNUC_WARN_UNUSED_RESULT;
+ 
+-ADW_AVAILABLE_IN_1_4
+-GtkWidget *adw_about_window_new_from_appdata (const char *resource_path,
+-                                              const char *release_notes_version) G_GNUC_WARN_UNUSED_RESULT;
+-
+ ADW_AVAILABLE_IN_1_2
+ const char *adw_about_window_get_application_name (AdwAboutWindow *self);
+ ADW_AVAILABLE_IN_1_2
+@@ -174,13 +170,6 @@ void adw_about_window_add_legal_section (AdwAboutWindow *self,
+ ADW_AVAILABLE_IN_1_2
+ void adw_show_about_window (GtkWindow  *parent,
+                             const char *first_property_name,
+-                            ...) G_GNUC_NULL_TERMINATED;
+-
+-ADW_AVAILABLE_IN_1_4
+-void adw_show_about_window_from_appdata (GtkWindow  *parent,
+-                                         const char *resource_path,
+-                                         const char *release_notes_version,
+-                                         const char *first_property_name,
+-                                         ...) G_GNUC_NULL_TERMINATED;
++                            ...);
+ 
+ G_END_DECLS
+diff --git a/src/meson.build b/src/meson.build
+index aa71da24..5d7db8c4 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -283,20 +283,12 @@ gtk_min_version = '>= 4.13.4'
+ 
+ gio_dep = dependency('gio-2.0', version: glib_min_version)
+ gtk_dep = dependency('gtk4', version: gtk_min_version)
+-appstream_dep = dependency('appstream',
+-  fallback : ['appstream', 'appstream_dep'],
+-  default_options : [
+-    'systemd=false', 'apidocs=false', 'install-docs=false',
+-    'stemming=false', 'svg-support=false', 'gir=false',
+-  ],
+-)
+ 
+ libadwaita_deps = [
+   dependency('glib-2.0', version: glib_min_version),
+   dependency('fribidi'),
+   gio_dep,
+   gtk_dep,
+-  appstream_dep,
+   cc.find_library('m', required: false),
+ ]
+ 
+diff --git a/subprojects/appstream.wrap b/subprojects/appstream.wrap
+deleted file mode 100644
+index 4262a04b..00000000
+--- a/subprojects/appstream.wrap
++++ /dev/null
+@@ -1,5 +0,0 @@
+-[wrap-git]
+-directory = appstream
+-url = https://github.com/ximion/appstream.git
+-revision = main
+-depth = 1
+diff --git a/tests/meson.build b/tests/meson.build
+index a5312488..64bc27d0 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -2,13 +2,6 @@ if get_option('tests')
+ 
+ subdir('manual')
+ 
+-test_resources = gnome.compile_resources(
+-   'adwaita-test-resources',
+-   'tests.gresources.xml',
+-
+-   c_name: 'test',
+-)
+-
+ test_env = [
+   'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
+   'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
+@@ -21,6 +14,7 @@ test_env = [
+ 
+ test_cflags = [
+   '-DADW_LOG_DOMAIN="Adwaita"',
++  '-DTEST_DATA_DIR="@0@/data"'.format(meson.current_source_dir()),
+ ]
+ 
+ test_link_args = []
+@@ -87,13 +81,7 @@ test_names = [
+ ]
+ 
+ foreach test_name : test_names
+-  test_sources = [
+-    test_name + '.c',
+-    test_resources,
+-    libadwaita_generated_headers
+-  ]
+-
+-  t = executable(test_name, test_sources,
++  t = executable(test_name, [test_name + '.c'] + libadwaita_generated_headers,
+                        c_args: test_cflags,
+                     link_args: test_link_args,
+                  dependencies: libadwaita_deps + [libadwaita_dep],
+diff --git a/tests/org.gnome.Adwaita1.Test.metainfo.xml b/tests/org.gnome.Adwaita1.Test.metainfo.xml
+deleted file mode 100644
+index 8b4af591..00000000
+--- a/tests/org.gnome.Adwaita1.Test.metainfo.xml
++++ /dev/null
+@@ -1,29 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<component type="desktop-application">
+-  <id>org.gnome.Adwaita1.Test</id>
+-  <metadata_license>CC0-1.0</metadata_license>
+-  <project_license>LGPL-2.1-or-later</project_license>
+-  <launchable type="desktop-id">org.gnome.Adwaita1.Test.desktop</launchable>
+-  <developer_name>The GNOME Project</developer_name>
+-
+-  <name>Adwaita Test</name>
+-
+-  <releases>
+-    <release version="1.0">
+-      <description>
+-        <p>Testing Build</p>
+-      </description>
+-    </release>
+-    <release version="0.1">
+-      <description>
+-        <p>Testing Build Older</p>
+-      </description>
+-    </release>
+-  </releases>
+-
+-  <project_group>GNOME</project_group>
+-
+-  <url type="homepage">https://gitlab.gnome.org/GNOME/libadwaita</url>
+-  <url type="bugtracker">https://gitlab.gnome.org/GNOME/libadwaita/issues</url>
+-  <url type="help">http://www.gnome.org/friends/</url>
+-</component>
+diff --git a/tests/test-about-dialog.c b/tests/test-about-dialog.c
+index 6c63aebf..f4577110 100644
+--- a/tests/test-about-dialog.c
++++ b/tests/test-about-dialog.c
+@@ -9,49 +9,6 @@
+ 
+ #include <adwaita.h>
+ 
+-#include "adwaita-test-resources.h"
+-
+-static void
+-test_adw_about_dialog_from_appdata (void)
+-{
+-  AdwAboutDialog *dialog = g_object_ref_sink (ADW_ABOUT_DIALOG (adw_about_dialog_new_from_appdata ("/org/gnome/Adwaita1/Test/org.gnome.Adwaita1.Test.metainfo.xml", "1.0")));
+-
+-  g_assert_nonnull (dialog);
+-
+-  g_assert_cmpstr (adw_about_dialog_get_release_notes (dialog), ==, "<p>Testing Build</p>\n");
+-  g_assert_cmpstr (adw_about_dialog_get_release_notes_version (dialog), ==, "1.0");
+-  g_assert_cmpstr (adw_about_dialog_get_version (dialog), ==, "1.0");
+-  g_assert_cmpstr (adw_about_dialog_get_application_icon (dialog), ==, "org.gnome.Adwaita1.Test");
+-  g_assert_cmpstr (adw_about_dialog_get_application_name (dialog), ==, "Adwaita Test");
+-  g_assert_cmpstr (adw_about_dialog_get_developer_name (dialog), ==, "The GNOME Project");
+-  g_assert_cmpstr (adw_about_dialog_get_issue_url (dialog), ==, "https://gitlab.gnome.org/GNOME/libadwaita/issues");
+-  g_assert_cmpstr (adw_about_dialog_get_support_url (dialog), ==, "http://www.gnome.org/friends/");
+-  g_assert_cmpstr (adw_about_dialog_get_website (dialog), ==, "https://gitlab.gnome.org/GNOME/libadwaita");
+-  g_assert_cmpuint (adw_about_dialog_get_license_type (dialog), ==, GTK_LICENSE_LGPL_2_1);
+-
+-  g_assert_finalize_object (dialog);
+-
+-  dialog = g_object_ref_sink (ADW_ABOUT_DIALOG (adw_about_dialog_new_from_appdata ("/org/gnome/Adwaita1/Test/org.gnome.Adwaita1.Test.metainfo.xml", "0.1")));
+-
+-  g_assert_nonnull (dialog);
+-
+-  g_assert_cmpstr (adw_about_dialog_get_release_notes (dialog), ==, "<p>Testing Build Older</p>\n");
+-  g_assert_cmpstr (adw_about_dialog_get_release_notes_version (dialog), ==, "0.1");
+-  g_assert_cmpstr (adw_about_dialog_get_version (dialog), ==, "1.0");
+-
+-  g_assert_finalize_object (dialog);
+-
+-  dialog = g_object_ref_sink (ADW_ABOUT_DIALOG (adw_about_dialog_new_from_appdata ("/org/gnome/Adwaita1/Test/org.gnome.Adwaita1.Test.metainfo.xml", NULL)));
+-
+-  g_assert_nonnull (dialog);
+-
+-  g_assert_cmpstr (adw_about_dialog_get_release_notes (dialog), ==, "");
+-  g_assert_cmpstr (adw_about_dialog_get_release_notes_version (dialog), ==, "");
+-  g_assert_cmpstr (adw_about_dialog_get_version (dialog), ==, "1.0");
+-
+-  g_assert_finalize_object (dialog);
+-}
+-
+ static void
+ test_adw_about_dialog_create (void)
+ {
+@@ -144,16 +101,10 @@ int
+ main (int   argc,
+       char *argv[])
+ {
+-  GResource *test_resources;
+-
+   gtk_test_init (&argc, &argv, NULL);
+   adw_init ();
+ 
+-  test_resources = test_get_resource ();
+-  g_resources_register (test_resources);
+-
+   g_test_add_func ("/Adwaita/AboutDialog/create", test_adw_about_dialog_create);
+-  g_test_add_func ("/Adwaita/AboutDialog/from_appdata", test_adw_about_dialog_from_appdata);
+ 
+   return g_test_run ();
+ }
 diff --git a/tests/test-about-window.c b/tests/test-about-window.c
---- a/tests/test-about-window.c	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ b/tests/test-about-window.c	(date 1702739024467)
+index 1deda1ee..667a4443 100644
+--- a/tests/test-about-window.c
++++ b/tests/test-about-window.c
 @@ -8,49 +8,6 @@
  
  #include <adwaita.h>
@@ -456,7 +959,7 @@ diff --git a/tests/test-about-window.c b/tests/test-about-window.c
  static void
  test_adw_about_window_create (void)
  {
-@@ -143,16 +100,10 @@
+@@ -143,16 +100,10 @@ int
  main (int   argc,
        char *argv[])
  {
@@ -473,199 +976,18 @@ diff --git a/tests/test-about-window.c b/tests/test-about-window.c
  
    return g_test_run ();
  }
-Index: tests/meson.build
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/tests/meson.build b/tests/meson.build
---- a/tests/meson.build	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ b/tests/meson.build	(date 1702739024414)
-@@ -2,13 +2,6 @@
- 
- subdir('manual')
- 
--test_resources = gnome.compile_resources(
--   'adwaita-test-resources',
--   'tests.gresources.xml',
--
--   c_name: 'test',
--)
--
- test_env = [
-   'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
-   'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
-@@ -21,6 +14,7 @@
- 
- test_cflags = [
-   '-DADW_LOG_DOMAIN="Adwaita"',
-+  '-DTEST_DATA_DIR="@0@/data"'.format(meson.current_source_dir()),
- ]
- 
- test_link_args = []
-@@ -83,13 +77,7 @@
- ]
- 
- foreach test_name : test_names
--  test_sources = [
--    test_name + '.c',
--    test_resources,
--    libadwaita_generated_headers
--  ]
--
--  t = executable(test_name, test_sources,
-+  t = executable(test_name, [test_name + '.c'] + libadwaita_generated_headers,
-                        c_args: test_cflags,
-                     link_args: test_link_args,
-                  dependencies: libadwaita_deps + [libadwaita_dep],
-Index: src/adw-about-window.h
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/src/adw-about-window.h b/src/adw-about-window.h
---- a/src/adw-about-window.h	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ b/src/adw-about-window.h	(date 1702739024348)
-@@ -25,10 +25,6 @@
- ADW_AVAILABLE_IN_1_2
- GtkWidget *adw_about_window_new (void) G_GNUC_WARN_UNUSED_RESULT;
- 
--ADW_AVAILABLE_IN_1_4
--GtkWidget *adw_about_window_new_from_appdata (const char *resource_path,
--                                              const char *release_notes_version) G_GNUC_WARN_UNUSED_RESULT;
--
- ADW_AVAILABLE_IN_1_2
- const char *adw_about_window_get_application_name (AdwAboutWindow *self);
- ADW_AVAILABLE_IN_1_2
-@@ -175,12 +171,5 @@
- void adw_show_about_window (GtkWindow  *parent,
-                             const char *first_property_name,
-                             ...);
--
--ADW_AVAILABLE_IN_1_4
--void adw_show_about_window_from_appdata (GtkWindow  *parent,
--                                         const char *resource_path,
--                                         const char *release_notes_version,
--                                         const char *first_property_name,
--                                         ...);
- 
- G_END_DECLS
-Index: demo/adwaita-demo.c
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/demo/adwaita-demo.c b/demo/adwaita-demo.c
---- a/demo/adwaita-demo.c	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ b/demo/adwaita-demo.c	(date 1702739024201)
-@@ -1,5 +1,3 @@
--#include "config.h"
--
- #include <glib/gi18n.h>
- #include <gtk/gtk.h>
- #include <adwaita.h>
-@@ -58,16 +56,24 @@
- 
-   debug_info = adw_demo_generate_debug_info ();
- 
--  about = adw_about_window_new_from_appdata ("/org/gnome/Adwaita1/Demo/org.gnome.Adwaita1.Demo.metainfo.xml", NULL);
--  gtk_window_set_transient_for (GTK_WINDOW (about), window);
--  adw_about_window_set_version (ADW_ABOUT_WINDOW (about), ADW_VERSION_S);
--  adw_about_window_set_debug_info (ADW_ABOUT_WINDOW (about), debug_info);
--  adw_about_window_set_debug_info_filename (ADW_ABOUT_WINDOW (about), "adwaita-1-demo-debug-info.txt");
--  adw_about_window_set_copyright (ADW_ABOUT_WINDOW (about), "© 2017–2022 Purism SPC");
--  adw_about_window_set_developers (ADW_ABOUT_WINDOW (about), developers);
--  adw_about_window_set_designers (ADW_ABOUT_WINDOW (about), designers);
--  adw_about_window_set_artists (ADW_ABOUT_WINDOW (about), designers);
--  adw_about_window_set_translator_credits (ADW_ABOUT_WINDOW (about), _("translator-credits"));
-+  about =
-+    g_object_new (ADW_TYPE_ABOUT_WINDOW,
-+                  "transient-for", window,
-+                  "application-icon", "org.gnome.Adwaita1.Demo",
-+                  "application-name", _("Adwaita Demo"),
-+                  "developer-name", _("The GNOME Project"),
-+                  "version", ADW_VERSION_S,
-+                  "website", "https://gitlab.gnome.org/GNOME/libadwaita",
-+                  "issue-url", "https://gitlab.gnome.org/GNOME/libadwaita/-/issues/new",
-+                  "debug-info", debug_info,
-+                  "debug-info-filename", "adwaita-1-demo-debug-info.txt",
-+                  "copyright", "© 2017–2022 Purism SPC",
-+                  "license-type", GTK_LICENSE_LGPL_2_1,
-+                  "developers", developers,
-+                  "designers", designers,
-+                  "artists", designers,
-+                  "translator-credits", _("translator-credits"),
-+                  NULL);
- 
-   adw_about_window_add_link (ADW_ABOUT_WINDOW (about),
-                              _("_Documentation"),
-Index: src/meson.build
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/src/meson.build b/src/meson.build
---- a/src/meson.build	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ b/src/meson.build	(date 1702739038248)
-@@ -271,20 +271,12 @@
- 
- gio_dep = dependency('gio-2.0', version: glib_min_version)
- gtk_dep = dependency('gtk4', version: gtk_min_version)
--appstream_dep = dependency('appstream',
--  fallback : ['appstream', 'appstream_dep'],
--  default_options : [
--    'systemd=false', 'apidocs=false', 'install-docs=false',
--    'stemming=false', 'svg-support=false', 'gir=false',
--  ],
--)
- 
- libadwaita_deps = [
-   dependency('glib-2.0', version: glib_min_version),
-   dependency('fribidi'),
-   gio_dep,
-   gtk_dep,
--  appstream_dep,
-   cc.find_library('m', required: false),
- ]
- 
-Index: demo/meson.build
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/demo/meson.build b/demo/meson.build
---- a/demo/meson.build	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ b/demo/meson.build	(date 1702739024229)
-@@ -3,7 +3,6 @@
- subdir('data')
- 
- demo_config_data = configuration_data()
--demo_config_data.set_quoted('ADW_METAINFO', appstream_file.full_path())
- demo_config_data.set_quoted('ADW_DEMO_VCS_TAG', '@VCS_TAG@')
- 
- demo_config_h = vcs_tag(
-@@ -19,8 +18,6 @@
-    'adwaita-demo.gresources.xml',
- 
-    c_name: 'adw',
--   dependencies: appstream_file,
--   source_dir: meson.current_build_dir(),
- )
- 
- adwaita_demo_sources = [
-Index: demo/adwaita-demo.gresources.xml
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/demo/adwaita-demo.gresources.xml b/demo/adwaita-demo.gresources.xml
---- a/demo/adwaita-demo.gresources.xml	(revision fd5892e94ddd9baf44dcfb2faaa97211a2532d6d)
-+++ b/demo/adwaita-demo.gresources.xml	(date 1702739024215)
-@@ -3,7 +3,6 @@
-   <gresource prefix="/org/gnome/Adwaita1/Demo">
-     <file preprocess="xml-stripblanks" alias="icons/scalable/apps/org.gnome.Adwaita1.Demo.svg">data/org.gnome.Adwaita1.Demo.svg</file>
-     <file preprocess="xml-stripblanks" alias="icons/symbolic/apps/org.gnome.Adwaita1.Demo-symbolic.svg">data/org.gnome.Adwaita1.Demo-symbolic.svg</file>
--    <file preprocess="xml-stripblanks" alias="org.gnome.Adwaita1.Demo.metainfo.xml">data/org.gnome.Adwaita1.Demo.metainfo.xml</file>
-     <file preprocess="xml-stripblanks">icons/scalable/actions/avatar-delete-symbolic.svg</file>
-     <file preprocess="xml-stripblanks">icons/scalable/actions/avatar-save-symbolic.svg</file>
-     <file preprocess="xml-stripblanks">icons/scalable/actions/clock-alarm-symbolic.svg</file>
+diff --git a/tests/tests.gresources.xml b/tests/tests.gresources.xml
+deleted file mode 100644
+index 23e90ea8..00000000
+--- a/tests/tests.gresources.xml
++++ /dev/null
+@@ -1,6 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<gresources>
+-  <gresource prefix="/org/gnome/Adwaita1/Test">
+-    <file compressed="true">org.gnome.Adwaita1.Test.metainfo.xml</file>
+-  </gresource>
+-</gresources>
+-- 
+2.44.0
+

--- a/gvsbuild/projects/libadwaita.py
+++ b/gvsbuild/projects/libadwaita.py
@@ -25,10 +25,10 @@ class Libadwaita(Tarball, Meson):
             self,
             "libadwaita",
             repository="https://gitlab.gnome.org/GNOME/libadwaita",
-            version="1.4.4",
+            version="1.5.0",
             lastversion_even=True,
             archive_url="https://download.gnome.org/sources/libadwaita/{major}.{minor}/libadwaita-{version}.tar.xz",
-            hash="f802b7d8d5ae33be4650ef571a580f144a806202a26f527dacd57d1560938828",
+            hash="fd92287df9bb95c963654fb6e70d3e082e2bcb37b147e0e3c905567167993783",
             dependencies=[
                 "ninja",
                 "meson",


### PR DESCRIPTION
Updates libadwaita to 1.5.

I updated the patch to include AdwAboutDialog.

I did some minimal testing using the artifact [built by GitHub Actions](https://github.com/theCapypara/gvsbuild/actions/runs/8544096763) and a simple AdwApplication, AdwApplicationWindow and AdwAboutDialog, generally it seems to work.