### PR TITLE
Enable Direct Write font support in Cairo and Harfbuzz

### DIFF
--- a/gvsbuild/projects/cairo.py
+++ b/gvsbuild/projects/cairo.py
@@ -31,6 +31,7 @@ class Cairo(Tarball, Meson):
             dependencies=["freetype", "glib", "pixman", "libpng"],
             patches=["0001-fix-alloca-unresolved.patch"],
         )
+        self.add_param("-Ddwrite=enabled")
         self.add_param("-Dfreetype=enabled")
         self.add_param("-Dfontconfig=disabled")
 

--- a/gvsbuild/projects/harfbuzz.py
+++ b/gvsbuild/projects/harfbuzz.py
@@ -36,6 +36,9 @@ class Harfbuzz(Tarball, Meson):
         else:
             self.add_param("-Dintrospection=disabled")
 
+        self.add_param("-Ddirectwrite=enabled")
+        self.add_param("-Dgdi=enabled")
+
     def build(self):
         Meson.build(self)
         self.install(r".\COPYING share\doc\harfbuzz")

--- a/gvsbuild/projects/librsvg.py
+++ b/gvsbuild/projects/librsvg.py
@@ -34,6 +34,7 @@ class Librsvg(Tarball, Project):
                 "pango",
                 "gdk-pixbuf",
                 "libxml2",
+                "freetype",
             ],
         )
         if Project.opts.enable_gi:


### PR DESCRIPTION
The discussion in #1324 made me realize that we weren't building Harfbuzz and Cairo with Direct Write support. This PR enables it and also fixes a missing dependency for librsvg.