### PR TITLE
Disable the GTK testsuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ to build GTK with `gvsbuild build gtk4 adwaita-icon-theme` which will include li
 rebuilding it with `--from-scratch`
 - If the download of a tarball fails a partial file will not pass the hash check,
 delete the file and try again.
+- If you get an out of memory error, reduce the number of processor cores building at once
+by adding the `--ninja-opts -j2` option, where 2 is the number of cores.
 
 ## OpenSSL
 

--- a/gvsbuild/projects/gtk.py
+++ b/gvsbuild/projects/gtk.py
@@ -147,6 +147,7 @@ class Gtk4(Tarball, Meson):
 
         self.add_param(f"-Dintrospection={enable_gi}")
         self.add_param("-Dbuild-tests=false")
+        self.add_param("-Dbuild-testsuite=false")
         self.add_param("-Dbuild-demos=false")
         self.add_param("-Dbuild-examples=false")
         self.add_param("-Dmedia-gstreamer=disabled")


### PR DESCRIPTION
Closes #1270. This also reduced the CI build time of GTK4 by about 4 min.