### PR TITLE
winginputstream | Fix sequential reads on winginputstream always starting from offset 0.

### DIFF
--- a/gvsbuild/patches/wing/0001-Fixes-issues-with-multiple-sequential-reads-on-files.patch
+++ b/gvsbuild/patches/wing/0001-Fixes-issues-with-multiple-sequential-reads-on-files.patch
@@ -1,0 +1,92 @@
+From a2b19e62057e30999651202477fbc5bd6636bb72 Mon Sep 17 00:00:00 2001
+From: Danilo Aimini <daimini@amazon.it>
+Date: Tue, 11 Jun 2024 18:09:05 +0200
+Subject: [PATCH] Fixes issues with multiple sequential reads on files always
+ starting from the beginning.
+
+---
+ wing/winginputstream.c | 31 ++++++++++++++++++++++++++++++-
+ 1 file changed, 30 insertions(+), 1 deletion(-)
+
+diff --git a/wing/winginputstream.c b/wing/winginputstream.c
+index 28bead8..72dc6d9 100644
+--- a/wing/winginputstream.c
++++ b/wing/winginputstream.c
+@@ -39,6 +39,7 @@
+ typedef struct {
+   HANDLE handle;
+   gboolean close_handle;
++  DWORD current_offset;
+ 
+   OVERLAPPED overlap;
+ } WingInputStreamPrivate;
+@@ -148,9 +149,18 @@ wing_input_stream_read (GInputStream  *stream,
+   overlap.hEvent = CreateEvent (NULL, FALSE, FALSE, NULL);
+   g_return_val_if_fail (overlap.hEvent != NULL, -1);
+ 
++  overlap.Offset = priv->current_offset;
++  
+   res = ReadFile (priv->handle, buffer, nbytes, &nread, &overlap);
+   if (res)
+-    retval = nread;
++    {
++      retval = nread;
++
++      if(GetFileType(priv->handle) == FILE_TYPE_DISK)
++        {
++          priv->current_offset += nbytes;
++        }
++    }
+   else
+     {
+       int errsv = GetLastError ();
+@@ -160,6 +170,12 @@ wing_input_stream_read (GInputStream  *stream,
+                                     &overlap, &nread, cancellable))
+         {
+           retval = nread;
++
++          if(GetFileType(priv->handle) == FILE_TYPE_DISK)
++            {
++              priv->current_offset += nbytes;
++            }
++            
+           goto end;
+         }
+ 
+@@ -308,6 +324,7 @@ wing_input_stream_read_async (GInputStream        *stream,
+     nbytes = count;
+ 
+   ResetEvent (priv->overlap.hEvent);
++  priv->overlap.Offset = priv->current_offset;
+ 
+   res = ReadFile (priv->handle, buffer, nbytes, &nread, &priv->overlap);
+   if (res)
+@@ -315,6 +332,12 @@ wing_input_stream_read_async (GInputStream        *stream,
+       ResetEvent (priv->overlap.hEvent);
+       g_task_return_int (task, nread);
+       g_object_unref (task);
++
++      if(GetFileType(priv->handle) == FILE_TYPE_DISK)
++        {
++          priv->current_offset += nbytes;
++        }
++      
+       return;
+     }
+ 
+@@ -328,6 +351,12 @@ wing_input_stream_read_async (GInputStream        *stream,
+       g_task_attach_source (task, handle_source,
+                             (GSourceFunc)read_async_ready);
+       g_source_unref (handle_source);
++
++      if(GetFileType(priv->handle) == FILE_TYPE_DISK)
++        {
++          priv->current_offset += nbytes;
++        }
++      
+       return;
+     }
+ 
+-- 
+2.33.0.windows.2
+

--- a/gvsbuild/projects/wing.py
+++ b/gvsbuild/projects/wing.py
@@ -29,6 +29,7 @@ class Wing(Tarball, Meson):
             archive_url="https://gitlab.gnome.org/GNOME/wing/-/archive/v{version}/wing-v{version}.tar.gz",
             hash="6d15984c917d9bdf2c88a06072991daf39a226d2024ec5b196a1c9ed8e81e962",
             dependencies=["ninja", "meson", "pkgconf", "glib"],
+            patches=['0001-Fixes-issues-with-multiple-sequential-reads-on-files.patch'],
         )
 
     def build(self):


### PR DESCRIPTION
In `winginputstream.c`, in both `wing_input_stream_read` and `wing_input_stream_read_async`, an `OVERLAPPED` struct is defined and passed to `ReadFile`. This is a requirement for handles that are created with the `FILE_FLAG_OVERLAPPED` attribute.

The issue is that this struct is always defined with default values for every read. As such, file reads executed using these read functions will always start over from the beginning of the file, while the expected behavior would be to continue reading from where we left off.

This problem is further exacerbated by the fact that this `OVERLAPPED` struct is always passed to ReadFile regardless of how the HANDLE is initialized. While the Windows documentation seems to suggest that this struct is only relevant when the `FILE_FLAG_OVERLAPPED` attribute is in play, the `Offset` value inside it is always used if the struct is provided. As such, all file handles suffer from this issue, especially when the code tries to split the read into multiple consecutive chunks.