### PR TITLE
pixman: Don't assume even/odd release scheme

### DIFF
--- a/gvsbuild/projects/pixman.py
+++ b/gvsbuild/projects/pixman.py
@@ -26,7 +26,6 @@ class Pixman(Tarball, Meson):
             "pixman",
             repository="https://gitlab.freedesktop.org/pixman/pixman",
             version="0.42.2",
-            lastversion_even=True,
             archive_url="http://cairographics.org/releases/pixman-{version}.tar.gz",
             hash="ea1480efada2fd948bc75366f7c349e1c96d3297d09a3fe62626e38e234a625e",
             dependencies=["ninja", "meson"],


### PR DESCRIPTION
"Note, in the past pixman used a numbering scheme with odd minor number numbers for development versions and even minor number for stable versions. This is no longer the case, all releases (including this one) are stable production versions now."

https://www.mail-archive.com/pixman@lists.freedesktop.org/msg04806.html