### PR TITLE
Build webrtcdsp gstreamer plugin with bad plugins

### DIFF
--- a/gvsbuild/projects/__init__.py
+++ b/gvsbuild/projects/__init__.py
@@ -90,6 +90,7 @@ from gvsbuild.projects.protobuf import Protobuf, ProtobufC
 from gvsbuild.projects.pycairo import Pycairo
 from gvsbuild.projects.pygobject import PyGObject
 from gvsbuild.projects.sqlite import SQLite
+from gvsbuild.projects.webrtc_audio_processing import WebrtcAudioProcessing
 from gvsbuild.projects.win_iconv import WinIconv
 from gvsbuild.projects.wing import Wing
 from gvsbuild.projects.x264 import X264

--- a/gvsbuild/projects/gstreamer.py
+++ b/gvsbuild/projects/gstreamer.py
@@ -155,13 +155,21 @@ class GstPluginsBad(Tarball, Meson):
             lastversion_even=True,
             archive_url="https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-{version}.tar.xz",
             hash="3029bfd7265314d609dc8eab503675a344ea46e8274fd73ab34566c8442dc847",
-            dependencies=["meson", "ninja", "gst-plugins-base"],
+            dependencies=[
+                "meson",
+                "ninja",
+                "gst-plugins-base",
+                "webrtc-audio-processing",
+            ],
             patches=[
                 "wasapisink-reduce-buffer-latency.patch",
             ],
         )
         self.add_param("-Dcurl=disabled")
         self.add_param("-Dcurl-ssh2=disabled")
+
+        # Adding webrtc-audio-processing adds the isac plugin. It fails to compile.
+        self.add_param("-Disac=disabled")
 
         if self.opts.enable_gi:
             self.add_dependency("gobject-introspection")

--- a/gvsbuild/projects/webrtc_audio_processing.py
+++ b/gvsbuild/projects/webrtc_audio_processing.py
@@ -1,0 +1,24 @@
+from gvsbuild.utils.base_builders import Meson
+from gvsbuild.utils.base_expanders import Tarball
+from gvsbuild.utils.base_project import Project, project_add
+
+
+@project_add
+class WebrtcAudioProcessing(Tarball, Meson):
+    def __init__(self):
+        Project.__init__(
+            self,
+            "webrtc-audio-processing",
+            repository="https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/",
+            version="1.3",
+            archive_url="https://freedesktop.org/software/pulseaudio/webrtc-audio-processing/webrtc-audio-processing-{version}.tar.gz",
+            hash="95552fc17faa0202133707bbb3727e8c2cf64d4266fe31bfdb2298d769c1db75",
+            dependencies=["meson", "ninja"],
+        )
+
+    def build(self):
+        Meson.build(self)
+        self.install(r".\COPYING share\doc\webrtc-audio-processing")
+        self.install(
+            r".\webrtc\LICENSE .\webrtc\PATENTS share\doc\webrtc-audio-processing\webrtc"
+        )


### PR DESCRIPTION
Certian gstreamer plugins are automatically disabled when the necessary dependencies aren't available. The webrtcdsp plugin is one of these and adding webrtc audio processing enables it to be built.