### PR TITLE
Revert "Update lz4 to version 1.10.0"

### DIFF
--- a/gvsbuild/projects/lz4.py
+++ b/gvsbuild/projects/lz4.py
@@ -23,10 +23,10 @@ class Lz4(Tarball, Project):
         Project.__init__(
             self,
             "lz4",
-            version="1.10.0",
+            version="1.9.4",
             archive_url="https://github.com/lz4/lz4/archive/v{version}.tar.gz",
             archive_filename="lz4-{version}.tar.gz",
-            hash="537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b",
+            hash="0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b",
         )
 
     def build(self):


### PR DESCRIPTION
It doesn't compile:
```
/programs/datagen.c(1,1): error C1083: Cannot open source file: '..\..\..\programs\datagen.c': No such file or director
y [C:\gtk-build\build\x64\release\lz4\visual\vs2022\datagen\datagen.vcxproj]
```

This reverts commit 3c190c2a48606f224830cbb5d5e30c046fae45c4.