### PR TITLE
Fix GTK4 icon and text corruption

### DIFF
--- a/gvsbuild/patches/gtk4/0001-ngl-icon-drawing-fix.patch
+++ b/gvsbuild/patches/gtk4/0001-ngl-icon-drawing-fix.patch
@@ -1,0 +1,11 @@
+--- gtk-4.14.1/gsk/gpu/shaders/common-gl.glsl.orig	2024-03-17 01:52:15.000000000 +0100
++++ gtk-4.14.1/gsk/gpu/shaders/common-gl.glsl	2024-03-29 12:55:20.259693400 +0100
+@@ -91,7 +91,7 @@
+ #define gsk_get_int(id) (floatBitsToInt(gsk_get_float(id)))
+ #define gsk_get_uint(id) (floatBitsToUint(gsk_get_float(id)))
+ 
+-#if __VERSION__ < 400 || defined(GSK_GLES)
++#if 1
+ 
+ vec4
+ gsk_texture (uint id,

--- a/gvsbuild/projects/gtk.py
+++ b/gvsbuild/projects/gtk.py
@@ -138,6 +138,7 @@ class Gtk4(Tarball, Meson):
                 "glib",
                 "fribidi",
             ],
+            patches=["0001-ngl-icon-drawing-fix.patch"],
         )
         if self.opts.enable_gi:
             self.add_dependency("gobject-introspection")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gvsbuild"
-version = "2024.8.0"
+version = "2024.8.1"
 description = "GTK stack for Windows"
 authors = ["Ignacio Casal Quinteiro <qignacio@amazon.com>", "Dan Yeaw <dan@yeaw.me>"]
 license = "GPL-2.0-only"


### PR DESCRIPTION
Fixes #1405 by taking part of an upstream patch.