### PR TITLE
Add ability to configure extra opts per project

### DIFF
--- a/gvsbuild/build.py
+++ b/gvsbuild/build.py
@@ -15,7 +15,7 @@
 
 from enum import Enum
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 import typer
 
@@ -57,6 +57,16 @@ def __get_projects_to_build(opts):
                 log.debug(f"Dropped project {s}")
                 to_build.remove(p)
     return to_build
+
+
+def __parse_extra_opts(extra_opts: List[str]) -> Dict[str, List[str]]:
+    if extra_opts is None:
+        return {}
+    parsed_opts = {}
+    for eo in extra_opts:
+        project, opts = eo.split(":")
+        parsed_opts[project] = opts.split(";")
+    return parsed_opts
 
 
 class Platform(str, Enum):
@@ -311,6 +321,12 @@ def build(
         help="Command line options to pass to cargo",
         rich_help_panel="Options to Pass to Build Systems",
     ),
+    extra_opts: List[str] = typer.Option(
+        None,
+        help="Additional command line options to pass to specific project."
+        " Example: --extra_opts <project>:<option1>[;<option1>...]",
+        rich_help_panel="Options to Pass to Build Systems",
+    ),
     git_expand_dir: Path = typer.Option(
         None,
         help="The directory where the projects from git are expanded and updated.",
@@ -386,6 +402,7 @@ def build(
     opts.log_single = log_single
     opts.cargo_opts = cargo_opts
     opts.ninja_opts = ninja_opts
+    opts.extra_opts = __parse_extra_opts(extra_opts)
     opts.capture_out = capture_out
     opts.print_out = print_out
 

--- a/gvsbuild/utils/base_builders.py
+++ b/gvsbuild/utils/base_builders.py
@@ -68,6 +68,9 @@ class Meson(Project):
         add_opts += f"--buildtype {build_type}"
         if meson_params:
             add_opts += f" {meson_params}"
+        if self.extra_opts:
+            extra_opts = " ".join(self.extra_opts)
+            add_opts += f" {extra_opts}"
         # python meson.py src_dir ninja_build_dir --prefix gtk_bin options
         meson = Project.get_tool_executable("meson")
         python = Path(sys.executable)
@@ -104,6 +107,9 @@ class CmakeProject(Project):
         cmd = f'cmake -G "{cmake_gen}" -DCMAKE_INSTALL_PREFIX="%(pkg_dir)s" -DGTK_DIR="%(gtk_dir)s" -DCMAKE_BUILD_TYPE={cmake_config}'
         if cmake_params:
             cmd += f" {cmake_params}"
+        if self.extra_opts:
+            extra_opts = " ".join(self.extra_opts)
+            cmd += f" {extra_opts}"
         if use_ninja and out_of_source is None:
             # For ninja the default is build out of source
             out_of_source = True
@@ -166,6 +172,9 @@ class Rust(Project):
             folder = "release"
         else:
             folder = "debug"
+
+        if self.extra_opts:
+            params.extend(self.extra_opts)
 
         cargo_build = os.path.join(self.build_dir, "cargo-build")
 

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -73,6 +73,7 @@ class Options:
         self.log_single = False
         self.cargo_opts = None
         self.ninja_opts = None
+        self.extra_opts = None
         self.capture_out = False
         self.print_out = False
         self.git_expand_dir = None
@@ -108,7 +109,7 @@ class Project(Generic[P]):
         self.extra_env = {}
         self.tag = None
         self.repo_url = None
-        self.archive_filename = None
+        self.extra_opts = None
 
         for k in kwargs:
             setattr(self, k, kwargs[k])

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -480,6 +480,8 @@ class Builder:
             proj.mark_file_calc()
             if self.opts.clean:
                 proj.clean = True
+            if self.opts.extra_opts and proj.name in self.opts.extra_opts:
+                proj.extra_opts = self.opts.extra_opts[proj.name]
 
         for proj in Project.list_projects():
             self.__compute_deps(proj)


### PR DESCRIPTION
Some users might want to be able to add additional options to the compilation command of each project.
With this, we add the `--extra-opts` build option which appends the passed option to a project's build command line.
The structure is:
`--extra-opts <project>:<option>[;<option>...]`

Closes: #1356 