### PR TITLE
Remove --outdated and --latest options from list command

### DIFF
--- a/gvsbuild/list.py
+++ b/gvsbuild/list.py
@@ -14,48 +14,11 @@
 #  along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import json
-import sys
 from typing import List
 
 import typer
-from packaging import version
 
 from gvsbuild.utils.base_project import Project, ProjectType
-
-
-def set_projects_latest_versions(projects):
-    try:
-        import lastversion
-    except ImportError:
-        print("Please pip install lastversion in your Python environment")
-        sys.exit(1)
-
-    projects = {
-        project.name: project
-        for project in Project.list_projects()
-        if project.type.value in [ProjectType.PROJECT, ProjectType.TOOL]
-        and not project.internal
-    }
-
-    try:
-        for project in projects.values():
-            if project.internal:
-                continue
-            project.latest_version = lastversion.latest(
-                repo=project.repository or project.name,
-                major=project.lastversion_major,
-            )
-            if project.latest_version:
-                project.outdated = version.parse(
-                    str(project.latest_version)
-                ) > version.parse(project.version)
-
-    except lastversion.exceptions.ApiCredentialsError:
-        print(
-            "Create or update the GITHUB token at https://github.com/settings/tokens, then set or update the token "
-            "environmental variable with:\n$env:GITHUB_API_TOKEN=xxxxxxxxxxxxxxx"
-        )
-        exit(1)
 
 
 def list_(
@@ -78,18 +41,6 @@ def list_(
         help="Show list in JSON format",
         rich_help_panel="Formatting Options",
     ),
-    latest: bool = typer.Option(
-        False,
-        "--latest",
-        help="Fetch latest information",
-        rich_help_panel="Formatting Options",
-    ),
-    outdated: bool = typer.Option(
-        False,
-        "--outdated",
-        help="Only show outdated projects",
-        rich_help_panel="Selection Options",
-    ),
 ):
     Project.add_all()
 
@@ -101,19 +52,6 @@ def list_(
     if project_type:
         projects = [
             project for project in projects if project.type.value == project_type
-        ]
-
-    if outdated:
-        latest = True
-
-    if latest:
-        set_projects_latest_versions(projects)
-
-    if outdated:
-        projects = [
-            project
-            for project in projects
-            if hasattr(project, "outdated") and project.outdated
         ]
 
     if json_:
@@ -145,16 +83,4 @@ def list_(
                         "name": f"{project.name:<{Project.name_len}}",
                         "version": f"{project.version:<45}",
                     }
-                    if latest:
-                        if (
-                            hasattr(project, "latest_version")
-                            and project.latest_version
-                        ):
-                            params["latest_version"] = (
-                                f"{str(project.latest_version):<45}"
-                            )
-                        else:
-                            params["latest_version"] = "undefined"
-                        print("\t{name} {version} {latest_version}".format(**params))
-                    else:
-                        print("\t{name} {version}".format(**params))
+                    print("\t{name} {version}".format(**params))


### PR DESCRIPTION
In the `list` command, both the `latest` and `outdated` options were buggy and were causing an exception.
This is the same as the `outdated` command, so use it instead.

_Originally posted by @danyeaw in https://github.com/wingtk/gvsbuild/issues/975#issuecomment-1595791167_:
> You did run in to a bug. I don't think the `--latest` or `--outdated` options are useful, since if you want to see outdated versions you can run `gvsbuild outdated`. So I'll open a PR to remove them.