### PR TITLE
Remove GTK4 zip from source distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,9 @@ jobs:
         run: |
           mv GTK${{ matrix.gtk-version }}_Gvsbuild_${{ github.sha }}_x64.zip GTK${{ matrix.gtk-version }}_Gvsbuild_${{ github.event.release.tag_name }}_x64.zip
           gh release upload ${{ github.event.release.tag_name }} "GTK${{ matrix.gtk-version }}_Gvsbuild_${{ github.event.release.tag_name }}_x64.zip"
+      - name: Cleanup Zip Files
+        if: github.event_name == 'release'
+        run: rm GTK${{ matrix.gtk-version }}_Gvsbuild_${{ github.event.release.tag_name }}_x64.zip
       - name: Create Source Dist and Wheel
         if: matrix.gtk-version == '4'
         run: uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gvsbuild"
-version = "2024.11.0"
+version = "2024.11.1"
 description = "GTK stack for Windows"
 readme = "README.md"
 requires-python = "<4.0,>=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "gvsbuild"
-version = "2024.11.0"
+version = "2024.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "build" },


### PR DESCRIPTION
During the 2024.11.0 release, the last step failed because PyPI said the file size was too large. During the `uv build` step, it was including the release zip file in the source distribution itself. The release did get uploaded to PyPI, but with the wheel only. This PR removes the zip file prior to building the distribution.

Once this is merged, I can release 2024.11.1.