### PR TITLE
Relock the lock file for dependabot updates

### DIFF
--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -1,0 +1,25 @@
+name: uv
+
+on:
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ secrets.UV_LOCK_PAT }}
+      - uses: astral-sh/setup-uv@3b9817b1bf26186f03ab8277bab9b827ea5cc254 # v0.4.17
+        with:
+          enable-cache: true
+      - run: uv lock
+      - uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5.0.1
+        with:
+          commit_message: Regenerate uv.lock


### PR DESCRIPTION
Dependabot doesn't currently support updating the uv.lock. This PR adds a new CI workflow that pushes an update to any pull request updating the pyproject.toml file to make sure that the uv.lock is up to date.