### PR TITLE
lz4: use self.push_location instead of Meson.push_location

### DIFF
--- a/gvsbuild/projects/lz4.py
+++ b/gvsbuild/projects/lz4.py
@@ -33,7 +33,7 @@ class Lz4(Tarball, Meson):
         self.add_param("-Dossfuzz=false")
 
     def build(self):
-        self.push_location("build/meson")
+        self.push_location(r".\build\meson")
         Meson.build(self)
         self.pop_location()
 

--- a/gvsbuild/projects/lz4.py
+++ b/gvsbuild/projects/lz4.py
@@ -33,8 +33,8 @@ class Lz4(Tarball, Meson):
         self.add_param("-Dossfuzz=false")
 
     def build(self):
-        Meson.push_location(self, "build/meson")
+        self.push_location("build/meson")
         Meson.build(self)
-        Meson.pop_location(self)
+        self.pop_location()
 
         self.install(r".\lib\LICENSE share\doc\lz4")


### PR DESCRIPTION
Mainly for consistency with the other projects