### PR TITLE
icu: Fix patch

### DIFF
--- a/gvsbuild/patches/icu/0001-Fix-circular-include-on-MS-Visual-Studio.patch
+++ b/gvsbuild/patches/icu/0001-Fix-circular-include-on-MS-Visual-Studio.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Fix circular include on MS Visual Studio
 
 Including ucal.h from a C file on MS VisualStudio triggers a circular include, which triggers a build fail.
 ---
- icu4c/source/common/unicode/platform.h | 6 +++---
+ source/common/unicode/platform.h | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/icu4c/source/common/unicode/platform.h b/icu4c/source/common/unicode/platform.h
+diff --git a/source/common/unicode/platform.h b/source/common/unicode/platform.h
 index b2fcb21ef1..81976eacd8 100644
---- a/icu4c/source/common/unicode/platform.h
-+++ b/icu4c/source/common/unicode/platform.h
+--- a/source/common/unicode/platform.h
++++ b/source/common/unicode/platform.h
 @@ -728,12 +728,12 @@
      /*
       * Notes:

--- a/gvsbuild/patches/icu/0001-Fix-circular-include-on-MS-Visual-Studio.patch
+++ b/gvsbuild/patches/icu/0001-Fix-circular-include-on-MS-Visual-Studio.patch
@@ -1,5 +1,5 @@
---- a/source/common/unicode/platform.h.orig	2024-12-19 16:23:37.488862706 +0100
-+++ b/source/common/unicode/platform.h	2024-12-19 16:24:38.342860469 +0100
+--- a/icu/source/common/unicode/platform.h.orig	2024-12-19 16:23:37.488862706 +0100
++++ b/icu/source/common/unicode/platform.h	2024-12-19 16:24:38.342860469 +0100
 @@ -733,7 +733,7 @@
       */
  #   if defined(__cplusplus)

--- a/gvsbuild/patches/icu/0001-Fix-circular-include-on-MS-Visual-Studio.patch
+++ b/gvsbuild/patches/icu/0001-Fix-circular-include-on-MS-Visual-Studio.patch
@@ -1,6 +1,25 @@
---- a/icu/source/common/unicode/platform.h.orig	2024-12-19 16:23:37.488862706 +0100
-+++ b/icu/source/common/unicode/platform.h	2024-12-19 16:24:38.342860469 +0100
-@@ -733,7 +733,7 @@
+From b0a600d2a3f7de6fd817d5b310f1f17f565d81db Mon Sep 17 00:00:00 2001
+From: Ignazio Pillai <ignazp@amazon.com>
+Date: Wed, 18 Dec 2024 12:49:47 +0100
+Subject: [PATCH] Fix circular include on MS Visual Studio
+
+Including ucal.h from a C file on MS VisualStudio triggers a circular include, which triggers a build fail.
+---
+ icu4c/source/common/unicode/platform.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/icu4c/source/common/unicode/platform.h b/icu4c/source/common/unicode/platform.h
+index b2fcb21ef1..81976eacd8 100644
+--- a/icu4c/source/common/unicode/platform.h
++++ b/icu4c/source/common/unicode/platform.h
+@@ -728,12 +728,12 @@
+     /*
+      * Notes:
+      * C++11 and C11 require support for UTF-16 literals
+-     * Doesn't work on Mac C11 (see workaround in ptypes.h)
+-     * or Cygwin less than 3.5.
++     * Doesn't work on Mac C11 (see workaround in ptypes.h),
++     * MS Visual Studio or Cygwin less than 3.5.
       */
  #   if defined(__cplusplus)
  #       define U_HAVE_CHAR16_T 1
@@ -9,3 +28,6 @@
  #       define U_HAVE_CHAR16_T 0
  #   else
          // conformant C11
+-- 
+2.38.1.windows.1
+


### PR DESCRIPTION
The patch was from the entire git repository, while the downloaded
archive is only about icu4c. Make the paths relative to the icu4c
project.