### PR TITLE
feat: add `openssl` and `libsrtp` to build dtls and srtp gstreamer plugins in gst-plugins-bad

### DIFF
--- a/gvsbuild/projects/__init__.py
+++ b/gvsbuild/projects/__init__.py
@@ -55,8 +55,8 @@ from gvsbuild.projects.libarchive import Libarchive
 from gvsbuild.projects.libcbor import Libcbor
 from gvsbuild.projects.libcurl import Libcurl
 from gvsbuild.projects.libepoxy import Libepoxy
-from gvsbuild.projects.libfido2 import Libfido2
 from gvsbuild.projects.libffi import Libffi
+from gvsbuild.projects.libfido2 import Libfido2
 from gvsbuild.projects.libgxps import Libgxps
 from gvsbuild.projects.libjpeg_turbo import LibjpegTurbo
 from gvsbuild.projects.libmicrohttpd import Libmicrohttpd
@@ -83,8 +83,7 @@ from gvsbuild.projects.mit_kerberos import Kerberos
 from gvsbuild.projects.nghttp2 import Nghttp2
 from gvsbuild.projects.ogg import Ogg
 from gvsbuild.projects.openh264 import OpenH264
-from gvsbuild.projects.openssl import OpenSSL
-from gvsbuild.projects.openssl import OpenSSLFips
+from gvsbuild.projects.openssl import OpenSSL, OpenSSLFips
 from gvsbuild.projects.opus import Opus
 from gvsbuild.projects.pango import Pango
 from gvsbuild.projects.pangomm import Pangomm

--- a/gvsbuild/projects/__init__.py
+++ b/gvsbuild/projects/__init__.py
@@ -67,6 +67,7 @@ from gvsbuild.projects.libpsl import Libpsl
 from gvsbuild.projects.librsvg import Librsvg
 from gvsbuild.projects.libsigcplusplus import Libsigcplusplus
 from gvsbuild.projects.libsoup import Libsoup2, Libsoup3
+from gvsbuild.projects.libsrtp2 import LibSRTP
 from gvsbuild.projects.libssh import Libssh, Libssh2
 from gvsbuild.projects.libtiff import Libtiff4
 from gvsbuild.projects.libuv import Libuv

--- a/gvsbuild/projects/gstreamer.py
+++ b/gvsbuild/projects/gstreamer.py
@@ -161,7 +161,8 @@ class GstPluginsBad(Tarball, Meson):
                 "gst-plugins-base",
                 "libnice",
                 "webrtc-audio-processing",
-                "openssl"
+                "openssl",
+                "libsrtp2",
             ],
             patches=[
                 "wasapisink-reduce-buffer-latency.patch",

--- a/gvsbuild/projects/gstreamer.py
+++ b/gvsbuild/projects/gstreamer.py
@@ -161,6 +161,7 @@ class GstPluginsBad(Tarball, Meson):
                 "gst-plugins-base",
                 "libnice",
                 "webrtc-audio-processing",
+                "openssl"
             ],
             patches=[
                 "wasapisink-reduce-buffer-latency.patch",

--- a/gvsbuild/projects/libsrtp2.py
+++ b/gvsbuild/projects/libsrtp2.py
@@ -1,0 +1,36 @@
+#  Copyright (C) 2025 The Gvsbuild Authors
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from gvsbuild.utils.base_builders import Meson
+from gvsbuild.utils.base_expanders import Tarball
+from gvsbuild.utils.base_project import Project, project_add
+
+
+@project_add
+class LibSRTP(Tarball, Meson):
+    def __init__(self):
+        Project.__init__(
+            self,
+            "libsrtp2",
+            repository="https://github.com/cisco/libsrtp",
+            version="2.5.0",
+            archive_url="https://github.com/cisco/libsrtp/archive/refs/tags/v{version}.tar.gz",
+            hash="8a43ef8e9ae2b665292591af62aa1a4ae41e468b6d98d8258f91478735da4e09",
+            dependencies=["meson", "ninja"],
+        )
+
+    def build(self):
+        Meson.build(self)
+        self.install(r".\LICENSE share\doc\libsrtp2")


### PR DESCRIPTION
## Problem

`webrtcbin` gstreamer element relies on dtls but it's not being built in gvsbuild's GstPluginsBad project. When I tried to use `webrtcbin` in my app, I got:
```
dtls elements are not available
```

I also saw that dtls was missing with gst-inspect-1.0:
```
PS C:\gtk-build\gtk\x64\release\bin> .\gst-inspect-1.0.exe dtls
No such element or plugin 'dtls'
```

As per https://gitlab.freedesktop.org/gstreamer/gstreamer/blob/main/subprojects/gst-plugins-bad/ext/dtls/meson.build#L24, dtls is part of gst-plugins-bad, and relies on gstreamer, libcrypto, openssl and winsock2.
```python
dependencies : [gst_dep, libcrypto_dep, openssl_dep] + winsock2,`
```

## Slow openssl
Adding openssl slows down the build significantly though:

![openssl](https://github.com/user-attachments/assets/0ead6262-057f-4048-961d-219445110b0e)
