### PR TITLE
Add missing gst-plugins-base dependencies

### DIFF
--- a/gvsbuild/projects/gstreamer.py
+++ b/gvsbuild/projects/gstreamer.py
@@ -101,6 +101,8 @@ class GstPluginsBase(Tarball, Meson):
                 "gstreamer",
                 "opus",
                 "ogg",
+                "graphene",
+                "pango",
             ],
         )
         # Examples depend on GTK3


### PR DESCRIPTION
I noticed that when building gst-libav from scratch, that gst-plugins-base was pulling in extra subprojects. This PR adds Pango and graphene as dependencies.