### PR TITLE
Add global option to toggle tests for all projects

### DIFF
--- a/gvsbuild/build.py
+++ b/gvsbuild/build.py
@@ -109,6 +109,10 @@ def build(
         "includes debug symbols for Meson and CMake projects - other "
         'projects\' build tools will interpret the option as "release"',
     ),
+    enable_tests: bool = typer.Option(
+        False,
+        help="Enable building tests during the build process. This will increase build time.",
+    ),
     build_dir: Path = typer.Option(
         Path(r"C:\gtk-build"),
         help="The full or relative path of the directory to build in",
@@ -389,6 +393,7 @@ def build(
     opts.py_wheel = py_wheel
     opts.enable_gi = enable_gi
     opts.enable_fips = enable_fips
+    opts.enable_tests = enable_tests
     opts.ffmpeg_enable_gpl = ffmpeg_enable_gpl
     opts.log_size = log_size
     opts.log_single = log_single

--- a/gvsbuild/projects/harfbuzz.py
+++ b/gvsbuild/projects/harfbuzz.py
@@ -39,6 +39,11 @@ class Harfbuzz(Tarball, Meson):
         self.add_param("-Ddirectwrite=enabled")
         self.add_param("-Dgdi=enabled")
 
+        if self.opts.enable_tests:
+            self.add_param("-Dtests=enabled")
+        else:
+            self.add_param("-Dtests=disabled")
+
     def build(self):
         Meson.build(self)
         self.install(r".\COPYING share\doc\harfbuzz")

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -38,6 +38,7 @@ class Options:
     def __init__(self):
         self.enable_gi = False
         self.enable_fips = False
+        self.enable_tests = False
         self.ffmpeg_enable_gpl = False
         self.verbose = False
         self.debug = False


### PR DESCRIPTION
The plan is to disable tests for all projects to reduce build time. The build options to disable tests can be added as usual. If someone needs tests for some reason it can be enabled using this global option without editing .py files.