### PR TITLE
Fix `cmake` not being found by turning off `strip_one`

### DIFF
--- a/gvsbuild/tools.py
+++ b/gvsbuild/tools.py
@@ -84,7 +84,6 @@ class ToolCmake(Tool):
             dir_part=self.dir_part,
             check_file=self.full_exe,
             check_mark=True,
-            strip_one=True,
         )
 
 


### PR DESCRIPTION
With `strip_one`, the contents of the `cmake*.zip` file go right into `gtk-build/tools/`, rather than `gtk-build/tools/cmake*/`.

This breaks later references, such as expecting `cmake` to be available at `gtk-build/tools/cmake*/bin/`.

Fixes #1559