### PR TITLE
Enable fontconfig on cairo and pango

### DIFF
--- a/gvsbuild/projects/cairo.py
+++ b/gvsbuild/projects/cairo.py
@@ -33,6 +33,7 @@ class Cairo(Tarball, Meson):
         )
         self.add_param("-Ddwrite=enabled")
         self.add_param("-Dfreetype=enabled")
+        self.add_param("-Dfontconfig=enabled")
         self.add_param("-Dtests=disabled")
 
     def build(self):

--- a/gvsbuild/projects/pango.py
+++ b/gvsbuild/projects/pango.py
@@ -31,6 +31,7 @@ class Pango(Tarball, Meson):
             dependencies=[
                 "ninja",
                 "meson",
+                "fontconfig",
                 "freetype",
                 "cairo",
                 "harfbuzz",
@@ -47,6 +48,7 @@ class Pango(Tarball, Meson):
 
         self.add_param(f"-Dintrospection={enable_gi}")
         self.add_param("-Dfreetype=enabled")
+        self.add_param("-Dfontconfig=enabled")
 
     def build(self):
         Meson.build(self)


### PR DESCRIPTION
Re-enables pangoft2. It seems like cairo was being compiled without fontconfig support (maybe because fontconfig was not in the dependency list?), so pangoft2 was getting disabled.
