### PR TITLE
Add projects to support gtkmm3

### DIFF
--- a/gvsbuild/projects/__init__.py
+++ b/gvsbuild/projects/__init__.py
@@ -3,9 +3,10 @@
 from gvsbuild.projects.abseil import AbseilCpp
 from gvsbuild.projects.adwaita_icon_theme import AdwaitaIconTheme
 from gvsbuild.projects.atk import Atk
+from gvsbuild.projects.atkmm import Atkmm
 from gvsbuild.projects.boringssl import BoringSSL
 from gvsbuild.projects.cairo import Cairo
-from gvsbuild.projects.cairomm import Cairomm
+from gvsbuild.projects.cairomm import Cairomm, Cairomm1_0
 from gvsbuild.projects.check_libs import CheckLibs
 from gvsbuild.projects.clutter import Clutter
 from gvsbuild.projects.cogl import Cogl
@@ -23,7 +24,7 @@ from gvsbuild.projects.fribidi import Fribidi
 from gvsbuild.projects.gdk_pixbuf import GdkPixbuf
 from gvsbuild.projects.gettext import Gettext
 from gvsbuild.projects.glib import GLib, GLibBase, GLibNetworking, GLibPyWrapper
-from gvsbuild.projects.glibmm import Glibmm
+from gvsbuild.projects.glibmm import Glibmm, Glibmm2_4
 from gvsbuild.projects.gobject_introspection import GObjectIntrospection
 from gvsbuild.projects.gperf import Gperf
 from gvsbuild.projects.graphene import Graphene
@@ -41,7 +42,7 @@ from gvsbuild.projects.gstreamer import (
     Orc,
 )
 from gvsbuild.projects.gtk import Gtk2, Gtk3, Gtk4
-from gvsbuild.projects.gtkmm import Gtkmm
+from gvsbuild.projects.gtkmm import Gtkmm, Gtkmm3
 from gvsbuild.projects.gtksourceview import GtkSourceView4, GtkSourceView5
 from gvsbuild.projects.harfbuzz import Harfbuzz
 from gvsbuild.projects.hello_world import HelloWorld
@@ -66,7 +67,7 @@ from gvsbuild.projects.libpanel import Libpanel
 from gvsbuild.projects.libpng import Libpng
 from gvsbuild.projects.libpsl import Libpsl
 from gvsbuild.projects.librsvg import Librsvg
-from gvsbuild.projects.libsigcplusplus import Libsigcplusplus
+from gvsbuild.projects.libsigcplusplus import Libsigcplusplus, Libsigcplusplus2
 from gvsbuild.projects.libsoup import Libsoup2, Libsoup3
 from gvsbuild.projects.libsrtp2 import LibSRTP
 from gvsbuild.projects.libssh import Libssh, Libssh2
@@ -88,7 +89,7 @@ from gvsbuild.projects.openh264 import OpenH264
 from gvsbuild.projects.openssl import OpenSSL, OpenSSLFips
 from gvsbuild.projects.opus import Opus
 from gvsbuild.projects.pango import Pango
-from gvsbuild.projects.pangomm import Pangomm
+from gvsbuild.projects.pangomm import Pangomm, Pangomm1_4
 from gvsbuild.projects.pcre2 import Pcre2
 from gvsbuild.projects.pixman import Pixman
 from gvsbuild.projects.pkgconf import PkgConf

--- a/gvsbuild/projects/atkmm.py
+++ b/gvsbuild/projects/atkmm.py
@@ -1,0 +1,38 @@
+#  Copyright (C) 2016 The Gvsbuild Authors
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from gvsbuild.utils.base_builders import Meson
+from gvsbuild.utils.base_expanders import Tarball
+from gvsbuild.utils.base_project import project_add
+
+
+@project_add
+class Atkmm(Tarball, Meson):
+    def __init__(self):
+        Meson.__init__(
+            self,
+            "atkmm",
+            prj_dir="atkmm-1.6",
+            version="2.28.4",
+            lastversion_even=True,
+            repository="https://gitlab.gnome.org/GNOME/atkmm",
+            archive_url="https://download.gnome.org/sources/atkmm/{major}.{minor}/atkmm-{version}.tar.xz",
+            hash="0a142a8128f83c001efb8014ee463e9a766054ef84686af953135e04d28fdab3",
+            dependencies=["meson", "ninja", "atk", "glibmm-2.4", "libsigc++-2.0"],
+        )
+
+    def build(self):
+        Meson.build(self, meson_params="-Dbuild-documentation=false")
+        self.install(r".\COPYING share\doc\atkmm-1.6")

--- a/gvsbuild/projects/cairomm.py
+++ b/gvsbuild/projects/cairomm.py
@@ -36,3 +36,22 @@ class Cairomm(Tarball, Meson):
             self, meson_params="-Dbuild-examples=false -Dbuild-documentation=false"
         )
         self.install(r".\COPYING share\doc\cairomm")
+
+
+@project_add
+class Cairomm1_0(Tarball, Meson):
+    def __init__(self):
+        Meson.__init__(
+            self,
+            "cairomm-1.0",
+            version="1.14.5",
+            archive_url="https://gitlab.freedesktop.org/cairo/cairomm/-/archive/{version}/cairomm-{version}.tar.gz",
+            hash="80c10611888e84c3a660eea0dafc81b6a9faf3e1d1cc31f950c51b3f7d384fc2",
+            dependencies=["meson", "ninja", "libsigc++-2.0", "cairo"],
+        )
+
+    def build(self):
+        Meson.build(
+            self, meson_params="-Dbuild-examples=false -Dbuild-documentation=false"
+        )
+        self.install(r".\COPYING share\doc\cairomm-1.0")

--- a/gvsbuild/projects/glibmm.py
+++ b/gvsbuild/projects/glibmm.py
@@ -49,3 +49,26 @@ class Glibmm(Tarball, Meson):
         )
 
         self.install(r".\COPYING share\doc\glibmm")
+
+
+@project_add
+class Glibmm2_4(Tarball, Meson):
+    def __init__(self):
+        Meson.__init__(
+            self,
+            "glibmm-2.4",
+            prj_dir="glibmm-2.4",
+            version="2.66.8",
+            lastversion_even=True,
+            repository="https://gitlab.gnome.org/GNOME/glibmm",
+            archive_url="https://download.gnome.org/sources/glibmm/{major}.{minor}/glibmm-{version}.tar.xz",
+            hash="64f11d3b95a24e2a8d4166ecff518730f79ecc27222ef41faf7c7e0340fc9329",
+            dependencies=["meson", "ninja", "libsigc++-2.0", "glib"],
+        )
+
+    def build(self):
+        Meson.build(
+            self, meson_params="-Dbuild-examples=false -Dbuild-documentation=false"
+        )
+
+        self.install(r".\COPYING share\doc\glibmm-2.4")

--- a/gvsbuild/projects/gtkmm.py
+++ b/gvsbuild/projects/gtkmm.py
@@ -48,3 +48,33 @@ class Gtkmm(Tarball, Meson):
         )
 
         self.install(r".\COPYING share\doc\gtkmm")
+
+
+@project_add
+class Gtkmm3(Tarball, Meson):
+    def __init__(self):
+        Meson.__init__(
+            self,
+            "gtkmm3",
+            prj_dir="gtkmm-3.0",
+            version="3.24.10",
+            lastversion_major=3,
+            lastversion_even=True,
+            repository="https://gitlab.gnome.org/GNOME/gtkmm",
+            archive_url="https://download.gnome.org/sources/gtkmm/{major}.{minor}/gtkmm-{version}.tar.xz",
+            hash="7ab7e2266808716e26c39924ace1fb46da86c17ef39d989624c42314b32b5a76",
+            dependencies=[
+                "gdk-pixbuf",
+                "pangomm-1.4",
+                "glibmm-2.4",
+                "libepoxy",
+                "cairomm-1.0",
+                "atkmm",
+                "gtk3",
+            ],
+        )
+
+    def build(self):
+        Meson.build(self, meson_params="-Dbuild-tests=false -Dbuild-demos=false")
+
+        self.install(r".\COPYING share\doc\gtkmm-3.0")

--- a/gvsbuild/projects/libsigcplusplus.py
+++ b/gvsbuild/projects/libsigcplusplus.py
@@ -42,3 +42,30 @@ class Libsigcplusplus(Tarball, Meson):
         )
 
         self.install(r".\COPYING share\doc\libsigc++")
+
+
+@project_add
+class Libsigcplusplus2(Tarball, Meson):
+    def __init__(self):
+        Project.__init__(
+            self,
+            "libsigc++-2.0",
+            prj_dir="libsigc++-2.0",
+            version="2.12.1",
+            lastversion_even=True,
+            repository="https://github.com/libsigcplusplus/libsigcplusplus",
+            archive_url="https://github.com/libsigcplusplus/libsigcplusplus/releases/download/{version}/libsigc++-{version}.tar.xz",
+            hash="a9dbee323351d109b7aee074a9cb89ca3e7bcf8ad8edef1851f4cf359bd50843",
+            dependencies=[
+                "meson",
+                "ninja",
+            ],
+        )
+
+    def build(self):
+        Meson.build(
+            self,
+            meson_params="-Dbuild-examples=false -Dbuild-documentation=false",
+        )
+
+        self.install(r".\COPYING share\doc\libsigc++-2.0")

--- a/gvsbuild/projects/pangomm.py
+++ b/gvsbuild/projects/pangomm.py
@@ -47,3 +47,33 @@ class Pangomm(Tarball, Meson):
         )
 
         self.install(r".\COPYING share\doc\glibmm")
+
+
+@project_add
+class Pangomm1_4(Tarball, Meson):
+    def __init__(self):
+        Meson.__init__(
+            self,
+            "pangomm-1.4",
+            prj_dir="pangomm-1.4",
+            version="2.46.4",
+            repository="https://gitlab.gnome.org/GNOME/pangomm",
+            archive_url="https://download.gnome.org/sources/pangomm/{major}.{minor}/pangomm-{version}.tar.xz",
+            hash="b92016661526424de4b9377f1512f59781f41fb16c9c0267d6133ba1cd68db22",
+            dependencies=[
+                "meson",
+                "ninja",
+                "libsigc++-2.0",
+                "cairomm-1.0",
+                "pango",
+                "glibmm-2.4",
+            ],
+        )
+
+    def build(self):
+        Meson.build(
+            self,
+            meson_params="-Dbuild-documentation=false",
+        )
+
+        self.install(r".\COPYING share\doc\pangomm-1.4")


### PR DESCRIPTION
closes #1599

adds:
- gtkmm-3.0
- atkmm-1.6
- pangomm-1.4
- cairomm-1.0
- glibmm-2.4
- libsigc++-2.0

i was able to build with `gvsbuild build gtkmm3` and compile a hello world project in visual studio.

since gtkmm3 has dependencies on older versions of other mm libraries with different ABI's i made separate projects suffixed with their abi version and left the existing ones as is