### PR TITLE
Add pip as a dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - name: Seed pip
-        run: uv venv --seed
       - name: Install the project
         run: uv sync --no-dev
       - name: Build GTK3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "build>=1.3.0",
     "typer>=0.19.2",
     "setuptools >=69.2; python_version >= \"3.12\"",
+    "pip",
 ]
 dynamic = []
 

--- a/uv.lock
+++ b/uv.lock
@@ -240,6 +240,7 @@ version = "2025.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "build" },
+    { name = "pip" },
     { name = "setuptools", marker = "python_full_version >= '3.12'" },
     { name = "typer" },
 ]
@@ -262,6 +263,7 @@ requires-dist = [
     { name = "build", specifier = ">=1.3.0" },
     { name = "lastversion", marker = "extra == 'outdated'", specifier = ">=2.4.2,<4.0.0" },
     { name = "packaging", marker = "extra == 'outdated'", specifier = ">=25.0" },
+    { name = "pip" },
     { name = "setuptools", marker = "python_full_version >= '3.12'", specifier = ">=69.2" },
     { name = "typer", specifier = ">=0.19.2" },
 ]
@@ -433,6 +435,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pip"
+version = "25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/16/650289cd3f43d5a2fadfd98c68bd1e1e7f2550a1a5326768cddfbcedb2c5/pip-25.2.tar.gz", hash = "sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2", size = 1840021, upload-time = "2025-07-30T21:50:15.401Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/3f/945ef7ab14dc4f9d7f40288d2df998d1837ee0888ec3659c813487572faa/pip-25.2-py3-none-any.whl", hash = "sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717", size = 1752557, upload-time = "2025-07-30T21:50:13.323Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
If you don't have pip installed via uv, then building pycairo can fail. This PR declares it as a dependency of the library.