### PR TITLE
fix(librsvg): build the pixbuf loader

### DIFF
--- a/gvsbuild/projects/librsvg.py
+++ b/gvsbuild/projects/librsvg.py
@@ -48,6 +48,7 @@ class Librsvg(Tarball, Meson):
         self.add_param("-Ddocs=disabled")
         self.add_param("-Dtests=false")
         self.add_param("-Dvala=disabled")
+        self.add_param("-Dpixbuf-loader=enabled")
 
     def build(self):
         self.builder.exec_cargo("install cargo-c --locked")


### PR DESCRIPTION
This PR adds the `-Dpixbuf-loader=enabled` meson parameter for librsvg, which builds pixbufloader_svg.dll, required for rsvg (and therefore svg rendering) to function correctly in GTK. The resulting DLL is properly installed automatically by meson.

I lost my mind for a while over this, trying to understand what I did wrong in my app for icons not to render at all, only to notice that the cause was a missing loader :-)