### PR TITLE
Add gst-plugin-gtk4

### DIFF
--- a/gvsbuild/projects/gstreamer.py
+++ b/gvsbuild/projects/gstreamer.py
@@ -331,6 +331,6 @@ class GstPluginGtk4(Tarball, Meson):
         self.add_param("--auto-features=disabled")
 
     def build(self):
-        self.builder.exec_cargo("install cargo-c")
+        self.builder.exec_cargo("install cargo-c --locked")
         Meson.build(self)
         self.install(r".\LICENSE-MPL-2.0 share\doc\gst-plugin-gtk4")


### PR DESCRIPTION
Hi, this is my attempt at implementing https://github.com/wingtk/gvsbuild/issues/1666

~~Unfortunately, I wasn't able to figure out how to translate the `cargo cinstall` command into something gvsbuild understands.~~

~~Test via: `gvsbuild build gst-plugin-gtk4`~~

~~Note that in the issue I describe that I grab the source of the plugin from their git repo matching gstreamer tag but here I went with grabbing the release from crates.io.~~
~~The reason is that they [mention ](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs#releases-and-git-tags) that distributors should use the versions available at crates.io instead of the git tags.~~

Edit: Fixed, working now

```
gvsbuild build gst-plugin-gtk4
gst-inspect-1.0.exe gtk4paintablesink
gst-launch-1.0.exe videotestsrc ! gtk4paintablesink
```