### PR TITLE
Download wing sources from github mirror

### DIFF
--- a/gvsbuild/projects/wing.py
+++ b/gvsbuild/projects/wing.py
@@ -26,8 +26,9 @@ class Wing(Tarball, Meson):
             "wing",
             version="0.3.24",
             repository="https://gitlab.gnome.org/GNOME/wing",
-            archive_url="https://gitlab.gnome.org/GNOME/wing/-/archive/v{version}/wing-v{version}.tar.gz",
-            hash="ea828739d77f1d1841863fddb693bf2ede9142ee47ba527f5946604a2635591e",
+            archive_url="https://github.com/GNOME/wing/archive/refs/tags/v{version}.tar.gz",
+            archive_filename="wing-v{version}.tar.gz",
+            hash="66c333973bb7efa2f6424ca3d3e03e60bd25e291292d0e766a18602ac797f62d",
             dependencies=["ninja", "meson", "pkgconf", "glib"],
         )
 


### PR DESCRIPTION
#1670 

GNOME gitlab servers are blocking downloads made with urllib of source archive tarballs, therefore change the URL and point it to the release archive on github