### PR TITLE
Improve error message when Visual Studio can't be found

### DIFF
--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -331,7 +331,7 @@ class Builder:
         log.log("Trying to find Visual Studio installations ...")
         if not os.path.exists(vswhere):
             log.log(f"Could not find vswhere executable ({vswhere})")
-            return
+            return []
 
         completed_process = subprocess.run(
             [f"{vswhere}", "-all", "-products", "*", "-format", "json", "-utf8"],
@@ -344,6 +344,7 @@ class Builder:
             return self.__extract_paths(vs_installs)
         except subprocess.CalledProcessError as e:
             log.log(f"Unable to call vswhere.exe to find Visual Studio with error {e}")
+            return []
 
     def __extract_paths(self, res):
         log.message("")

--- a/tests/utils/test_builder.py
+++ b/tests/utils/test_builder.py
@@ -50,7 +50,7 @@ def test_vs_check_error_if_vcvars_fails(tmp_path):
     opts.platform = "x64"
     builder = Builder.__new__(Builder)
     builder.opts = opts
-    vcvars_path = tmp_path / "VC" / "Auxiliary" / "build" / "vcvars64.bat"
+    vcvars_path = tmp_path / "VC" / "Auxiliary" / "Build" / "vcvars64.bat"
     vcvars_path.parent.mkdir(parents=True)
     vcvars_path.write_text("exit 1")
 
@@ -63,7 +63,7 @@ def test_vs_check_error_if_vcvars_no_env(tmp_path):
     opts.platform = "x64"
     builder = Builder.__new__(Builder)
     builder.opts = opts
-    vcvars_path = tmp_path / "VC" / "Auxiliary" / "build" / "vcvars64.bat"
+    vcvars_path = tmp_path / "VC" / "Auxiliary" / "Build" / "vcvars64.bat"
     vcvars_path.parent.mkdir(parents=True)
     vcvars_path.write_text("exit 0")
 
@@ -78,7 +78,7 @@ def test_vs_check_success(tmp_path):
     opts.platform = "x64"
     builder = Builder.__new__(Builder)
     builder.opts = opts
-    vcvars_path = tmp_path / "VC" / "Auxiliary" / "build" / "vcvars64.bat"
+    vcvars_path = tmp_path / "VC" / "Auxiliary" / "Build" / "vcvars64.bat"
     vcvars_path.parent.mkdir(parents=True)
     vcvars_path.write_text("SET FOO=BAR")
     builder._Builder__check_vs_install(opts, str(tmp_path), False)


### PR DESCRIPTION
This addresses the confusion of `gvsbuild` showing that it _found_ Visual Studio installations, but then logging right after that it couldn't, in fact, find it.

This tweaks the list of detected VS installations to also include logs when an installation is considered "inapplicable", such as because:
* The version doesn't match `vs_ver`
* The `vcvars.bat` is missing