### PR TITLE
Enable FFmpeg MP2 audio decoder

### DIFF
--- a/gvsbuild/patches/ffmpeg/build/build.sh
+++ b/gvsbuild/patches/ffmpeg/build/build.sh
@@ -41,6 +41,7 @@ configure_cmd[idx++]="--enable-hwaccel=hevc_nvdec"
 configure_cmd[idx++]="--disable-programs"
 configure_cmd[idx++]="--disable-avdevice"
 configure_cmd[idx++]="--disable-swresample"
+configure_cmd[idx++]="--enable-decoder=mp2float"
 
 if [ "$build_type" = "debug" ]; then
     configure_cmd[idx++]="--enable-debug"


### PR DESCRIPTION
This enables FFmpeg MP2 audio decoder which is commonly used in .ts files

The use-case I had for this is to play .ts files with Gstreamer via gst-libav as none of the other gstreamer plugins come with a decoder for this audio codec.

Just curious, what is the intended use-case for the ffmpeg build within gvsbuild? I assume it is to cover things which are not natively supported in gstreamer via gst-libav? Asking because the ffmpeg build config is very stripped down so wasn't sure you're interested in this...