### PR TITLE
Fix gobject-introspection build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ classifiers = [
 ]
 dependencies = [
     "build>=1.3.0",
-    "setuptools >=69.2; python_version >= \"3.12\"",
+    # setuptools upper bound fixes building of gobject-introspection: https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/575
+    "setuptools >=69.2, <81; python_version >= \"3.12\"",
     "cyclopts>=4.0.0b2",
     "pip",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -279,7 +279,7 @@ requires-dist = [
     { name = "lastversion", marker = "extra == 'outdated'", specifier = ">=2.4.2,<4.0.0" },
     { name = "packaging", marker = "extra == 'outdated'", specifier = ">=25.0" },
     { name = "pip" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'", specifier = ">=69.2" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'", specifier = ">=69.2,<81" },
 ]
 provides-extras = ["outdated"]
 


### PR DESCRIPTION
Hi, recent version of setuptools breaks gobject-introspection build (https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/575)

Locally I fixed this via
```
uv tool install gvsbuild --with "setuptools<81"
```

So I think for now it's probably best to restrict setuptools upper version

You can see the error also in this PR from dependabot https://github.com/wingtk/gvsbuild/pull/1717 which updated to latest setuptools