### PR TITLE
Handle None value for skip in make_graph

### DIFF
--- a/gvsbuild/deps.py
+++ b/gvsbuild/deps.py
@@ -47,12 +47,12 @@ def print_deps(flatten: bool = False, add_all: bool = False):
             done.append(name)
 
         rt = False
-        p = Project._dict[name]
+        p = Project.get_project(name)
         if p.dependencies:
             for d in p.dependencies:
                 add = True
                 if not add_all:
-                    ty = Project._dict[d].type
+                    ty = Project.get_project(d).type
                     if ty != ProjectType.PROJECT:
                         add = False
 
@@ -66,7 +66,7 @@ def print_deps(flatten: bool = False, add_all: bool = False):
                         dump_single_dep(f"{st}    ", d, flatten)
         return rt
 
-    prj = [x.name for x in Project._projects if x.type == ProjectType.PROJECT]
+    prj = [x.name for x in Project.list_projects() if x.type == ProjectType.PROJECT]
     print("Projects dependencies:")
     for n in prj:
         done = []
@@ -121,9 +121,9 @@ def make_graph(
         print(f"Writing file {out_file}")
         used: set[str] = set()
         fo.write("digraph gtk3dep {\n")
-        for n in Project._names:
+        for n in Project.get_names():
             if n not in to_skip:
-                t = Project._dict[n]
+                t = Project.get_project(n)
 
                 add = True
                 if t.type == ProjectType.TOOL:
@@ -155,7 +155,7 @@ def make_graph(
 
         if put_all:
             # Puts all projects that are not referenced from others
-            for n in Project._names:
+            for n in Project.get_names():
                 if n not in used:
                     fo.write(f'    "BUILD" -> "{n}" [color="#c00080"];\n')
 

--- a/gvsbuild/deps.py
+++ b/gvsbuild/deps.py
@@ -30,10 +30,10 @@ GRAPH_GROUP = Group("Graph Options", sort_key=1)
 GRAPH_FILTER_GROUP = Group("Graph Filter Options", sort_key=2)
 
 
-def print_deps(flatten=False, add_all=False):
-    done = []
+def print_deps(flatten: bool = False, add_all: bool = False):
+    done: list[str] = []
 
-    def dump_single_dep(st, name, flatten):
+    def dump_single_dep(st: str, name: str, flatten: bool):
         if flatten:
             if not st:
                 done.append(name)
@@ -83,12 +83,12 @@ def print_deps(flatten=False, add_all=False):
 
 
 def make_graph(
-    out_file,
-    put_all=False,
-    invert_dep=False,
-    add_tools=False,
-    add_groups=False,
-    skip=None,
+    out_file: str,
+    put_all: bool = False,
+    invert_dep: bool = False,
+    add_tools: bool = False,
+    add_groups: bool = False,
+    skip: list[str] | None = None,
 ):
     gr_colors = [
         0x000080,
@@ -119,7 +119,7 @@ def make_graph(
     to_skip = set(skip or [])
     with open(out_file, "w", encoding="utf-8") as fo:
         print(f"Writing file {out_file}")
-        used = set()
+        used: set[str] = set()
         fo.write("digraph gtk3dep {\n")
         for n in Project._names:
             if n not in to_skip:

--- a/gvsbuild/deps.py
+++ b/gvsbuild/deps.py
@@ -116,7 +116,7 @@ def make_graph(
     ]
     gr_index = 0
 
-    to_skip = set(skip)
+    to_skip = set(skip or [])
     with open(out_file, "w", encoding="utf-8") as fo:
         print(f"Writing file {out_file}")
         used = set()


### PR DESCRIPTION
If `skip=None` is used when creating a dependency graph, an error will occur.

```ps
PS C:\gtk-build\github\gvsbuild> uv run gvsbuild deps  --graph --gv-file test.gv
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\gtk-build\github\gvsbuild\.venv\Scripts\gvsbuild.exe\__main__.py", line 10, in <module>
    sys.exit(run())
             ~~~^^
  File "C:\gtk-build\github\gvsbuild\gvsbuild\main.py", line 45, in run
    app()
    ~~~^^
  File "C:\gtk-build\github\gvsbuild\.venv\Lib\site-packages\cyclopts\core.py", line 1841, in __call__
    result = _run_maybe_async_command(command, bound, resolved_backend)
  File "C:\gtk-build\github\gvsbuild\.venv\Lib\site-packages\cyclopts\_run.py", line 50, in _run_maybe_async_command
    return command(*bound.args, **bound.kwargs)
  File "C:\gtk-build\github\gvsbuild\gvsbuild\deps.py", line 206, in deps
    make_graph(
    ~~~~~~~~~~^
        out_file=gv_file,
        ^^^^^^^^^^^^^^^^^
    ...<4 lines>...
        skip=skip,
        ^^^^^^^^^^
    )
    ^
  File "C:\gtk-build\github\gvsbuild\gvsbuild\deps.py", line 119, in make_graph
    to_skip = set(skip)
TypeError: 'NoneType' object is not iterable
```

This PR handles the case where `skip=None` and adds type annotations.