### PR TITLE
Fetch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,40 @@ SHA256 hash of each download. Downloads are done using TLS, using SSL
 certificates provided by the system, but in case of error the download is tried
 again ignoring certificate errors.
 
+### Source caching and offline builds
+
+This feature supports a common workflow where one machine populates a source
+cache and another machine builds from it.
+
+Typical use cases:
+
+- Populate or refresh a source mirror from a Linux server or CI job.
+- Reuse the same cached sources on a Windows build machine.
+- Keep the sources in-house so builds are less exposed to upstream server or
+  network issues.
+
+The workflow is usually split into two runs:
+
+1. `--fetch-only` downloads tarball sources and also clones git-based projects
+   so it can create mirror archives under the archives download directory.
+2. `--offline` tells the build to use only already downloaded tarballs and git
+   mirror archives, and to fail instead of falling back to the network when a
+   source is missing.
+
+```PowerShell
+uv run gvsbuild build --fetch-only --no-deps x264
+uv run gvsbuild build --offline x264
+```
+
+For git-based projects, the mirror archive is keyed by the resolved commit hash
+that was checked out, plus a download timestamp. If multiple snapshots exist
+for the same commit, the most recent one is used.
+
+`--offline` is still a build mode, so it keeps the normal build environment
+requirements on Windows. It is intended to consume a pre-populated source cache,
+not to replace the build toolchain. If a required source archive or mirror is
+missing, the build fails immediately instead of trying to reach the network.
+
 First, we need to install the prerequisites. There are two main options:
 
 1. WinGet - Available for Windows 11, and modern versions of Windows 10

--- a/gvsbuild/build.py
+++ b/gvsbuild/build.py
@@ -136,6 +136,8 @@ def build(
         Configuration, Parameter(group=BUILD_CONFIG_GROUP)
     ] = Configuration.debug_optimized,
     check_hash: Annotated[bool, Parameter(group=BUILD_CONFIG_GROUP)] = False,
+    fetch_only: Annotated[bool, Parameter(group=BUILD_CONFIG_GROUP)] = False,
+    offline: Annotated[bool, Parameter(group=BUILD_CONFIG_GROUP)] = False,
     build_dir: Annotated[Path, Parameter(group=DIRECTORY_GROUP)] = Path(
         r"C:\gtk-build"
     ),
@@ -217,6 +219,8 @@ def build(
         net_target_framework: .net target framework. If set then TargetFrameworks parameter is passed down to msbuild with the specific target. i.e net45.
         net_target_framework_version: .net target framework version. If set then TargetFrameworkVersion parameter is passed down to msbuild with the specific version. i.e v4.6.2.
         check_hash: If set, only check the hash of the downloaded archives, no build.
+        fetch_only: If set, only download and hash-check the source archives, no build. Unlike check_hash this does not require the build toolchain (msys2, Visual Studio), so it can run on any platform, e.g. to populate a mirror.
+        offline: If set, never contact the network. Use the already downloaded tarballs and the git checkouts restored from their mirror archives, and fail if any source is missing. Use together with a pre-populated archives download dir, typically created with --fetch-only.
         clean: If set, clean the build directory before building.
         clean_built: If set, clean only the projects asked on the command line, not all the ones to build (via a dependency).
         deps: If not set, don't build the dependencies of the projects.
@@ -286,6 +290,8 @@ def build(
     opts.use_env = use_env
     opts.deps = deps
     opts.check_hash = check_hash
+    opts.fetch_only = fetch_only
+    opts.offline = offline
     opts.skip = skip
     opts.make_zip = make_zip
     opts.zip_continue = zip_continue
@@ -308,8 +314,10 @@ def build(
 
     if opts.make_zip and not opts.deps:
         log.error_exit("Options --make-zip and --no-deps are not compatible")
+    if opts.fetch_only and opts.offline:
+        log.error_exit("Options --fetch-only and --offline are not compatible")
     prop_file = patches_root_dir / "stack.props"
-    if not Path.is_file(prop_file):
+    if not fetch_only and not Path.is_file(prop_file):
         log.error_exit(
             f"Missing 'stack.props' file on directory {opts.patches_root_dir}.\n"
             "Wrong or missing --patches-root-dir option?"

--- a/gvsbuild/utils/base_expanders.py
+++ b/gvsbuild/utils/base_expanders.py
@@ -27,6 +27,7 @@ import zipfile
 from collections.abc import Iterator
 from pathlib import Path
 
+from . import offline_repos
 from .simple_ui import log
 from .utils import rmtree_full
 
@@ -486,10 +487,33 @@ class GitRepo:
     def unpack(self):
         self.update_build_dir()
 
+    def fetch_to_mirror(self):
+        """Populate the offline mirror archive for this git project."""
+        offline_repos.fetch_to_mirror(self)
+
     def _update_dir(self, remove_dest=False):
         dest = os.path.join(self.opts.git_expand_dir, self.name)
         if (self.clean or remove_dest) and os.path.isdir(dest):
             rmtree_full(dest)
+
+        if self.opts.offline:
+            # Never hit the network: reconstruct the checkout from the mirror
+            # archive and check out the pinned revision without fetching.
+            if not os.path.isdir(dest) and not offline_repos.restore_mirror_archive(
+                self, dest
+            ):
+                log.error_exit(
+                    f"offline: no mirror archive for git project '{self.name}' "
+                    f"in {os.path.join(self.opts.archives_download_dir, 'git')}"
+                )
+            log.start(f"(git) Checking out {dest} offline")
+            if self.tag:
+                self.builder.exec_msys(f"git checkout -f {self.tag}", working_dir=dest)
+            else:
+                self.builder.exec_msys("git checkout -f", working_dir=dest)
+            if self.fetch_submodules:
+                self._update_submodules("Update submodule(s)", dest)
+            return self.create_zip()
 
         if not os.path.isdir(dest):
             return self._clone_and_checkout(dest)

--- a/gvsbuild/utils/base_project.py
+++ b/gvsbuild/utils/base_project.py
@@ -61,6 +61,8 @@ class Options:
         self.use_env = False
         self.deps = False
         self.check_hash = False
+        self.fetch_only = False
+        self.offline = False
         self.skip = False
         self.make_zip = False
         self.zip_continue = False

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -159,8 +159,12 @@ class Builder:
         c:\windows\XXXX directory and the git one.
 
         The LIB, LIBPATH & INCLUDE environment are also cleaned to avoid
-        mismatch with  libs / programs already installed
+        mismatch with  libs / programs already installed.
+
+        No-op on non-Windows platforms.
         """
+        if os.name != "nt":
+            return
 
         log.start("Cleaning up the build environment")
         win_dir = os.environ.get("SYSTEMROOT", r"c:\windows").lower()
@@ -227,6 +231,8 @@ class Builder:
         return missing
 
     def __check_tools(self, opts):
+        if os.name != "nt":
+            return
         script_title("* Msys tool")
         log.start("Checking msys tool")
         msys_path = opts.msys_dir
@@ -397,6 +403,8 @@ class Builder:
         return vs_environment
 
     def __check_vs(self, opts):
+        if os.name != "nt":
+            return
         script_title("* Msvc tool")
         log.start("Checking Msvc tool")
 
@@ -486,7 +494,11 @@ class Builder:
             proj.export_dir = self.opts.export_dir
             proj.dependencies = [Project.get_project(dep) for dep in proj.dependencies]
             proj.dependents = []
-            proj.load_defaults()
+            # load_defaults() wires up build-time tool paths (msys, Visual
+            # Studio, ...) that are unavailable off-Windows. Fetching sources
+            # only needs archive_url/archive_file, computed above, so skip it.
+            if not self.opts.fetch_only:
+                proj.load_defaults()
             proj.mark_file_calc()
             if self.opts.clean:
                 proj.clean = True
@@ -531,7 +543,7 @@ class Builder:
         if self.__prepare_build(projects):
             return
 
-        if self.opts.check_hash:
+        if self.opts.check_hash or self.opts.fetch_only:
             return
 
         # List of all the project we can mark for build because of a dependent
@@ -603,9 +615,13 @@ class Builder:
             log.log(f"Creating working directory {self.working_dir}")
             os.makedirs(self.working_dir)
 
-        shutil.copy(
-            os.path.join(self.opts.patches_root_dir, "stack.props"), self.working_dir
-        )
+        if not self.opts.fetch_only:
+            # stack.props is only needed for Windows builds. Source download-only
+            # runs on any platform and should not require it.
+            shutil.copy(
+                os.path.join(self.opts.patches_root_dir, "stack.props"),
+                self.working_dir,
+            )
 
         build_dir = os.path.join(
             self.working_dir, "..", "..", "..", "gtk", self.opts.platform
@@ -621,6 +637,16 @@ class Builder:
         script_title("* Downloading")
         log.start("Downloading packages")
         for p in projects:
+            # When populating a mirror, also fetch git-based sources (which have
+            # no archive_file and are otherwise only cloned at build time) into
+            # their offline mirror archive.
+            if (
+                self.opts.fetch_only
+                and not p.archive_file
+                and hasattr(p, "fetch_to_mirror")
+            ):
+                p.fetch_to_mirror()
+                continue
             if self.__download_one(p):
                 return True
         log.end()
@@ -780,7 +806,7 @@ class Builder:
                 return True
 
             # Print the correct hash
-            if self.opts.check_hash:
+            if self.opts.check_hash or self.opts.fetch_only:
                 log.message(f"Hash ok on {proj.archive_file} ({hc})")
             else:
                 log.debug(f"Hash ok on {proj.archive_file} ({hc})")
@@ -875,6 +901,12 @@ class Builder:
             )
 
             os.makedirs(self.opts.archives_download_dir)
+
+        if self.opts.offline:
+            log.error_exit(
+                f"offline: archive not found for project '{proj.name}' "
+                f"at {proj.archive_file}"
+            )
 
         log.start_verbose(f"Downloading {proj.archive_file}")
         # Setup for progress show

--- a/gvsbuild/utils/offline_repos.py
+++ b/gvsbuild/utils/offline_repos.py
@@ -1,0 +1,177 @@
+#  Copyright (C) 2016 The Gvsbuild Authors
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Offline mirror support for git-based projects.
+
+git projects are normally cloned from their upstream repository at build time.
+To support fully offline builds (and to populate a source mirror), this module
+can archive a whole checkout - including the .git directory - into a single zip
+under the archives download dir, and later reconstruct it without any network
+access.
+
+The functions here take a GitRepo-like object exposing: name, tag, repository,
+fetch_submodules, and opts (with archives_download_dir and git_expand_dir).
+"""
+
+import glob
+import os
+import subprocess
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .simple_ui import log
+from .utils import rmtree_full
+
+_ARCHIVE_SUFFIX = ".git.zip"
+
+
+def _git_mirror_dir(repo):
+    return os.path.join(repo.opts.archives_download_dir, "git")
+
+
+def mirror_archive_write_path(repo, commit):
+    """Path of the offline mirror archive for a git project, named by the
+    resolved commit hash and download timestamp. The hash is a stable content
+    identifier regardless of whether the project pins a full hash, a short hash
+    or a branch/tag; the timestamp lets us prefer the newest cached snapshot
+    when multiple archives exist."""
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    return os.path.join(
+        _git_mirror_dir(repo), f"{repo.name}-{commit}-{stamp}{_ARCHIVE_SUFFIX}"
+    )
+
+
+def _archive_name_parts(repo, path):
+    """Return (commit, timestamp) for a mirror archive path, or None."""
+    filename = os.path.basename(path)
+    prefix = f"{repo.name}-"
+    if not filename.startswith(prefix) or not filename.endswith(_ARCHIVE_SUFFIX):
+        return None
+
+    body = filename[len(prefix) : -len(_ARCHIVE_SUFFIX)]
+    try:
+        commit, stamp = body.rsplit("-", 1)
+    except ValueError:
+        return None
+
+    return commit, stamp
+
+
+def _find_mirror_archive_for_commit(repo, commit):
+    """Locate the cached archive for a specific commit hash, if present."""
+    matches = glob.glob(
+        os.path.join(_git_mirror_dir(repo), f"{repo.name}-{commit}-*{_ARCHIVE_SUFFIX}")
+    )
+    if not matches:
+        return None
+
+    return max(matches, key=lambda path: _archive_name_parts(repo, path)[1])
+
+
+def find_mirror_archive(repo):
+    """Locate the offline mirror archive for a git project without any network
+    access. The commit hash in the name cannot be recomputed offline, so match
+    by project name and prefer the most recently downloaded snapshot. Returns
+    the path or None if not present."""
+    matches = []
+    for path in glob.glob(
+        os.path.join(_git_mirror_dir(repo), f"{repo.name}-*{_ARCHIVE_SUFFIX}")
+    ):
+        parts = _archive_name_parts(repo, path)
+        if parts:
+            matches.append((parts[1], path))
+
+    if not matches:
+        return None
+
+    return max(matches, key=lambda item: item[0])[1]
+
+
+def _walk_files(root):
+    """Return every file/dir path under root, preserving case (unlike
+    dirlist2set, which lowercases names for the Windows build)."""
+    paths = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        for name in dirnames:
+            paths.append(os.path.join(dirpath, name))
+        for name in filenames:
+            paths.append(os.path.join(dirpath, name))
+    return paths
+
+
+def _resolve_commit(dest):
+    """Return the full commit hash checked out at dest."""
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=dest, text=True
+    ).strip()
+
+
+def create_mirror_archive(repo, src_dir):
+    """Zip the whole checkout at src_dir (including .git) into the offline
+    mirror archive, named by the resolved commit hash."""
+    commit = _resolve_commit(src_dir)
+    mirror = _find_mirror_archive_for_commit(repo, commit)
+    if mirror:
+        log.debug(f"(git) mirror archive for {repo.name} at {commit} already exists")
+        return
+
+    mirror = mirror_archive_write_path(repo, commit)
+    os.makedirs(os.path.dirname(mirror), exist_ok=True)
+    log.start(f"(git) Creating mirror archive {mirror}")
+    files = _walk_files(src_dir)
+    with zipfile.ZipFile(mirror, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for f in sorted(files):
+            zf.write(f, arcname=os.path.relpath(f, src_dir))
+    log.end()
+
+
+def restore_mirror_archive(repo, dest):
+    """Reconstruct the checkout at dest from the offline mirror archive.
+    Returns True on success, False if the archive is missing."""
+    mirror = find_mirror_archive(repo)
+    if not mirror:
+        return False
+    log.start(f"(git) Restoring {dest} from mirror archive {mirror}")
+    os.makedirs(dest, exist_ok=True)
+    dest_path = Path(dest).resolve()
+    with zipfile.ZipFile(mirror, "r") as zf:
+        for member in zf.namelist():
+            member_path = (dest_path / member).resolve()
+            if not member_path.is_relative_to(dest_path):
+                raise RuntimeError(f"Unsafe path in mirror archive: {member}")
+            zf.extract(member, dest)
+    log.end()
+    return True
+
+
+def fetch_to_mirror(repo):
+    """Clone the repository and create the offline mirror archive, using plain
+    git (not msys) so it can run on any platform. The archive path is keyed by
+    the resolved commit hash, so a changed checkout gets a new archive."""
+    dest = os.path.join(repo.opts.git_expand_dir, repo.name)
+    os.makedirs(repo.opts.git_expand_dir, exist_ok=True)
+    if os.path.isdir(dest):
+        rmtree_full(dest)
+
+    log.start(f"(git) Cloning {repo.repository} to {dest}")
+    subprocess.check_call(["git", "clone", repo.repository, dest])
+    if repo.tag:
+        subprocess.check_call(["git", "checkout", "-f", repo.tag], cwd=dest)
+    if repo.fetch_submodules:
+        subprocess.check_call(["git", "submodule", "update", "--init"], cwd=dest)
+    log.end()
+
+    create_mirror_archive(repo, dest)

--- a/gvsbuild/utils/simple_ui.py
+++ b/gvsbuild/utils/simple_ui.py
@@ -32,6 +32,9 @@ def script_title(new_title):
 
     Passing None to the title restores the old, saved, one
     """
+    # Win32 console title updates are Windows-only and cosmetic.
+    if os.name != "nt":
+        return
 
     global _script_org_title
     if new_title:

--- a/tests/test_offline_repos.py
+++ b/tests/test_offline_repos.py
@@ -1,0 +1,91 @@
+#  Copyright (C) 2026 The Gvsbuild Authors
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+import zipfile
+from types import SimpleNamespace
+
+from gvsbuild.utils import offline_repos
+
+
+def _make_repo(tmp_path):
+    return SimpleNamespace(
+        name="foo",
+        repository="https://example.invalid/foo.git",
+        tag=None,
+        fetch_submodules=False,
+        opts=SimpleNamespace(
+            archives_download_dir=str(tmp_path / "archives"),
+            git_expand_dir=str(tmp_path / "git"),
+        ),
+    )
+
+
+def test_find_mirror_archive_prefers_latest_timestamp(tmp_path):
+    repo = _make_repo(tmp_path)
+    mirror_dir = tmp_path / "archives" / "git"
+    mirror_dir.mkdir(parents=True)
+
+    older = mirror_dir / "foo-aaa-20260101T010101.000001Z.git.zip"
+    newer = mirror_dir / "foo-bbb-20260102T010101.000001Z.git.zip"
+    older.write_bytes(b"old")
+    newer.write_bytes(b"new")
+
+    assert offline_repos.find_mirror_archive(repo) == str(newer)
+
+
+def test_create_mirror_archive_skips_existing_commit_snapshot(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    mirror_dir = tmp_path / "archives" / "git"
+    mirror_dir.mkdir(parents=True)
+    existing = mirror_dir / "foo-aaa-20260101T010101.000001Z.git.zip"
+    existing.write_bytes(b"cached")
+
+    monkeypatch.setattr(offline_repos, "_resolve_commit", lambda src_dir: "aaa")
+
+    called = []
+
+    def fail_if_called(*args, **kwargs):
+        called.append(True)
+        raise AssertionError("ZipFile should not be called for cached commits")
+
+    monkeypatch.setattr(offline_repos.zipfile, "ZipFile", fail_if_called)
+    monkeypatch.setattr(offline_repos.log, "debug", lambda *args, **kwargs: None)
+
+    offline_repos.create_mirror_archive(repo, str(tmp_path))
+
+    assert not called
+
+
+def test_restore_mirror_archive_rejects_path_traversal(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    mirror_dir = tmp_path / "archives" / "git"
+    mirror_dir.mkdir(parents=True)
+    mirror = mirror_dir / "foo-aaa-20260101T010101.000001Z.git.zip"
+
+    with zipfile.ZipFile(mirror, "w") as zf:
+        zf.writestr("../outside.txt", "evil")
+
+    monkeypatch.setattr(offline_repos, "find_mirror_archive", lambda _repo: str(mirror))
+    monkeypatch.setattr(offline_repos.log, "start", lambda *args, **kwargs: None)
+    monkeypatch.setattr(offline_repos.log, "end", lambda *args, **kwargs: None)
+
+    dest = tmp_path / "restore"
+
+    try:
+        offline_repos.restore_mirror_archive(repo, str(dest))
+    except RuntimeError as exc:
+        assert "Unsafe path" in str(exc)
+    else:
+        raise AssertionError("restore_mirror_archive should reject traversal paths")


### PR DESCRIPTION
This PR adds support for downloading all required sources separately from the build and then building without network access.

It introduces:

* `--fetch-only` is the cache/mirror population mode. It can run on Linux or any other host, and its job is to download the sources and create the git mirror archives.

* `--offline` is still a build mode. It avoids network access by reusing the already downloaded sources and mirror archives, but it keeps the normal build-environment requirements on Windows.

Example:

```bash
gvsbuild --fetch-only --archives-download-dir /path/to/sources gtk4
```

The source directory can then be copied to the build machine:
```
gvsbuild build --offline \
    --archives-download-dir C:\gvs-sources \
    gtk4
```
Git-based projects are stored as archives containing the complete repository, including submodules and revision information, so they can be restored without contacting the remote server.

The download command also skips Windows-specific build-tool checks, making it possible to prepare the source cache on another platform.