### PR TITLE
Use glob pattern for x264 PDB file installation

### DIFF
--- a/gvsbuild/projects/x264.py
+++ b/gvsbuild/projects/x264.py
@@ -61,7 +61,7 @@ class X264(GitRepo, Project):
         )
 
         if configuration in ["debug-optimized", "debug"]:
-            self.install(r".\libx264-164.pdb bin")
+            self.install(r".\libx264-*.pdb bin")
             self.install(r".\x264.pdb bin")
 
         self.install(r".\COPYING share\doc\x264")


### PR DESCRIPTION
The PDB filename was hardcoded with x264 SONAME version 164 that would silently fail to install after a version bump. Use a glob pattern instead, making this resilient to future version changes.