### PR TITLE
Skip clone if archive exists

### DIFF
--- a/gvsbuild/utils/offline_repos.py
+++ b/gvsbuild/utils/offline_repos.py
@@ -168,6 +168,16 @@ def fetch_to_mirror(repo):
     """Clone the repository and create the offline mirror archive, using plain
     git (not msys) so it can run on any platform. The archive path is keyed by
     the resolved commit hash, so a changed checkout gets a new archive."""
+
+    # skip if the archive for the pinned commit already exists
+    if repo.tag:
+        existing = _find_mirror_archive_for_commit(repo, repo.tag)
+        if existing:
+            log.debug(
+                f"(git) mirror archive for {repo.name} at {repo.tag} already exists with name '{existing}'"
+            )
+            return
+
     dest = os.path.join(repo.opts.git_expand_dir, repo.name)
     os.makedirs(repo.opts.git_expand_dir, exist_ok=True)
     if os.path.isdir(dest):

--- a/gvsbuild/utils/offline_repos.py
+++ b/gvsbuild/utils/offline_repos.py
@@ -71,10 +71,17 @@ def _archive_name_parts(repo, path):
 
 
 def _find_mirror_archive_for_commit(repo, commit):
-    """Locate the cached archive for a specific commit hash, if present."""
-    matches = glob.glob(
-        os.path.join(_git_mirror_dir(repo), f"{repo.name}-{commit}-*{_ARCHIVE_SUFFIX}")
-    )
+    """Locate the cached archive for a specific commit hash, if present.
+    Supports both full and short (prefix) commit hashes."""
+
+    matches = []
+    for path in glob.glob(
+        os.path.join(_git_mirror_dir(repo), f"{repo.name}-{commit}*{_ARCHIVE_SUFFIX}")
+    ):
+        parts = _archive_name_parts(repo, path)
+        if parts and parts[0].startswith(commit):
+            matches.append(path)
+
     if not matches:
         return None
 


### PR DESCRIPTION
Apply misc fixes to avoid unnecessary downloads with the new `--fetch-only` option.