### PR TITLE
[WIP] clear RUSTC_WRAPPER when env not empty

### DIFF
--- a/gvsbuild/projects/gettext.py
+++ b/gvsbuild/projects/gettext.py
@@ -28,7 +28,7 @@ class Gettext(Tarball, Project):
             "gettext",
             version="0.21",
             repository="https://github.com/autotools-mirror/gettext",
-            archive_url="http://mirrors.ibiblio.org/gnu/gettext/gettext-{version}.tar.xz",
+            archive_url="http://ftpmirror.gnu.org/gnu/gettext/gettext-{version}.tar.xz",
             hash="d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192",
             dependencies=["win-iconv"],
             patches=[

--- a/gvsbuild/projects/gperf.py
+++ b/gvsbuild/projects/gperf.py
@@ -26,7 +26,7 @@ class Gperf(Tarball, Meson):
             "gperf",
             version="3.1",
             repository="https://savannah.gnu.org/git/?group=gperf",
-            archive_url="https://mirrors.ibiblio.org/gnu/gperf/gperf-{version}.tar.gz",
+            archive_url="https://ftpmirror.gnu.org/gnu/gperf/gperf-{version}.tar.gz",
             hash="588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2",
             dependencies=["ninja"],
         )

--- a/gvsbuild/projects/libmicrohttpd.py
+++ b/gvsbuild/projects/libmicrohttpd.py
@@ -28,7 +28,7 @@ class Libmicrohttpd(Tarball, Project):
             version="1.0.3",
             lastversion_major=1,
             repository="https://www.gnu.org/software/libmicrohttpd/",
-            archive_url="https://mirrors.ibiblio.org/gnu/libmicrohttpd/libmicrohttpd-{version}.tar.gz",
+            archive_url="https://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-{version}.tar.gz",
             hash="7816b57aae199cf5c3645e8770e1be5f0a4dfafbcb24b3772173dc4ee634126a",
             patches=["001-remove-postsample-perf-retries.patch"],
         )

--- a/gvsbuild/utils/builder.py
+++ b/gvsbuild/utils/builder.py
@@ -1050,6 +1050,8 @@ class Builder:
         if add_path:
             env = dict(env) if env is not None else dict(os.environ)
             self.__add_path(env, add_path)
+        if env:
+            env["RUSTC_WRAPPER"] = ""
         args = self.__resolve_executable(args, env)
         if self.opts.capture_out:
             try:


### PR DESCRIPTION
Fixes #1822
If the RUSTC_WRAPPER is set to a invalid path, it will lead some packages fails to build.
Mask this by explicitly setting it to empty.