### PR TITLE
Update OpenSSL to 3.6.3, Downgrade FIPS version to 3.1.2

### DIFF
--- a/gvsbuild/projects/openssl.py
+++ b/gvsbuild/projects/openssl.py
@@ -26,10 +26,10 @@ class OpenSSL(Tarball, Project):
         Project.__init__(
             self,
             "openssl",
-            version="3.6.1",
+            version="3.6.3",
             repository="https://github.com/openssl/openssl",
             archive_url="https://github.com/openssl/openssl/releases/download/openssl-{version}/openssl-{version}.tar.gz",
-            hash="b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e",
+            hash="243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1",
             dependencies=[
                 "perl",
                 "nasm",

--- a/gvsbuild/projects/openssl.py
+++ b/gvsbuild/projects/openssl.py
@@ -79,10 +79,10 @@ class OpenSSLFips(Tarball, Project):
         Project.__init__(
             self,
             "openssl-fips",
-            version="3.6.1",
+            version="3.1.2",
             repository="https://github.com/openssl/openssl",
             archive_url="https://www.openssl.org/source/old/{major}.{minor}/openssl-{version}.tar.gz",
-            hash="b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e",
+            hash="a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539",
             dependencies=[
                 "openssl",
             ],


### PR DESCRIPTION
* Update OpenSSL to version 3.6.3
* Downgrade FIPS OpenSSL to version 3.1.2:
  As for https://openssl-library.org/source, the latest OpenSSL version that is FIPS validated is 3.1.2, not 3.6.1